### PR TITLE
separating config and games directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ services:
       # Setup auth
       - USERNAME=a1ex
       - PASSWORD=pass
-      # - ROOT_DIR=/games
       # - SAVE_ENABLED=true
     volumes:
+      - /your/config/directory:/config
       - /your/game/directory:/games
     ports:
       - "8000:80"

--- a/app/app.py
+++ b/app/app.py
@@ -21,11 +21,11 @@ logger = logging.getLogger("main")
 if __name__ == "__main__":
     scheduler = BlockingScheduler()
     # Get config
-    root_dir = config["root_dir"]
+    games_dir = config["games_dir"]
     scan_interval = int(config["shop"]["scan_interval"])
 
     # Add scheduled jobs
-    job_gen_shop = scheduler.add_job(gen_shop, 'interval', args=[root_dir], minutes=scan_interval, id='gen_shop', name='Generate shop', next_run_time=datetime.now())
+    job_gen_shop = scheduler.add_job(gen_shop, 'interval', args=[games_dir], minutes=scan_interval, id='gen_shop', name='Generate shop', next_run_time=datetime.now())
     try:
         save_interval = int(config["saves"]["interval"])
         if config['saves']['enabled']:

--- a/app/backup_saves.py
+++ b/app/backup_saves.py
@@ -192,7 +192,7 @@ def backup_saves():
             continue
         logger.info(f'Successfully connected to Switch device on host {host}.')
         for folder in switch_conf['folders']:
-            switch_ftp.retrieve_saves(config['root_dir'] + '/' + folder['local'], folder['remote'])
+            switch_ftp.retrieve_saves(config['games_dir'] + '/' + folder['local'], folder['remote'])
 
 
 # PyFTPclient license from https://github.com/keepitsimple/pyFTPclient/blob/master/LICENSE

--- a/app/run.sh
+++ b/app/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Get root_dir from env, defaults to /games
-root_dir="${ROOT_DIR:-/games}"
+# Get config_dir from env, defaults to /config
+config_dir="${CONFIG_DIR:-/config}"
 
 gid=${PGID:-1000}
 uid=${PUID:-1000}
@@ -28,8 +28,8 @@ fi
 chown -R ${uid}:${gid} /app
 
 # Copy the shop config and template if it does not already exists
-cp -np /app/shop_config.toml $root_dir/shop_config.toml
-cp -np /app/shop_template.toml $root_dir/shop_template.toml
+cp -np /app/shop_config.toml $config_dir/shop_config.toml
+cp -np /app/shop_template.toml $config_dir/shop_template.toml
 
 # Setup nginx basic auth if needed
 if [[ ! -z $USERNAME && ! -z $PASSWORD ]]; then
@@ -43,4 +43,4 @@ fi
 # Start nginx and app
 echo "Starting ownfoil"
 nginx -g "daemon off;" &
-sudo -u $gt_user python /app/app.py $root_dir/shop_config.toml
+sudo -u $gt_user python /app/app.py $config_dir/shop_config.toml

--- a/app/shop_config.toml
+++ b/app/shop_config.toml
@@ -1,4 +1,4 @@
-root_dir = "/games"
+games_dir = "/games"
 
 [shop]
 # Scan interval, in minutes

--- a/app/utils.py
+++ b/app/utils.py
@@ -11,7 +11,6 @@ logger.basicConfig(format='%(asctime)s - %(levelname)s %(name)s: %(message)s', l
 
 # Set environment variables to override properties from configuration file
 CONFIG_KEYS = {
-    "ROOT_DIR": "root_dir",
     "SCAN_INTERVAL": "shop.scan_interval",
     "SHOP_TEMPLATE": "shop.template",
     "SAVE_ENABLED": "saves.enabled",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       # Uncomment to setup basic auth
       # - USERNAME=a1ex
       # - PASSWORD=
-      # - ROOT_DIR=/games
       # - SAVE_ENABLED=true
     volumes:
+      - /your/config/directory:/config
       - /your/game/directory:/games
     ports:
       - "8000:80"


### PR DESCRIPTION
Fixing Issue #27

This pull request is to separate the config and games directories.
This will help keep the following private and secure in **shop_template.toml**:

```
1Fichier API key
Google API key

clientCertPub = "-----BEGIN PUBLIC KEY----- ...."
clientCertKey = "-----BEGIN PRIVATE KEY----- ...."
```

Please double check my code as this is my first commit on this project. Thanks!