### PR TITLE
Fix: permissions for /games

### DIFF
--- a/app/run.sh
+++ b/app/run.sh
@@ -26,6 +26,7 @@ else
 fi
 
 chown -R ${uid}:${gid} /app
+chown -R ${uid}:${gid} $root_dir/games
 
 # Copy the shop config and template if it does not already exists
 cp -np /app/shop_config.toml $root_dir/shop_config.toml


### PR DESCRIPTION
I'm not at all versed in these things, but this completely removed any error messages I kept receiving in my container logs.