### PR TITLE
fix(save_manager): do not close the connection if the file is empty

### DIFF
--- a/app/backup_saves.py
+++ b/app/backup_saves.py
@@ -149,7 +149,6 @@ class PyFTPclient:
 
             if not dst_filesize:
                 logger.debug(f'Downloaded file {dst_filename} is empty.')
-                self.ftp.close()
                 return 1
 
             mon = monitor()


### PR DESCRIPTION
The PR #42 introduced a bug that leads to a backup failure when it encounters an empty file.

It should not close the connection if it finds an empty file, I honestly don't know how my tests didn't catch that.

### Error
```
2023-10-18 05:15:39,071 - DEBUG save_manager: Retrieving /JKSV/Animal Crossing  New Horizons/Device - 2023.10.17 @ 23.34.16/main.dat
2023-10-18 05:15:39,084 - DEBUG save_manager: Downloaded file /JKSV/Animal Crossing  New Horizons/Device - 2023.10.17 @ 23.34.16/main.dat is empty.
2023-10-18 05:15:39,088 - ERROR apscheduler.executors.default: Job "Backup saves (trigger: interval[1:00:00], next run at: 2023-10-18 06:15:22 UTC)" raised an exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backup_saves.py", line 202, in backup_saves
    r = switch_ftp.retrieve_saves(config['root_dir'] + '/' + folder['local'], folder['remote'])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backup_saves.py", line 110, in retrieve_saves
    children = self.get_files(file)
               ^^^^^^^^^^^^^^^^^^^^
  File "/app/backup_saves.py", line 95, in get_files
    files = self.ftp.nlst(path)
            ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/ftplib.py", line 553, in nlst
    self.retrlines(cmd, files.append)
  File "/usr/local/lib/python3.11/ftplib.py", line 461, in retrlines
    resp = self.sendcmd('TYPE A')
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/ftplib.py", line 280, in sendcmd
    self.putcmd(cmd)
  File "/usr/local/lib/python3.11/ftplib.py", line 207, in putcmd
    self.putline(line)
  File "/usr/local/lib/python3.11/ftplib.py", line 202, in putline
    self.sock.sendall(line.encode(self.encoding))
    ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'sendall'
```


### Logs after removing the pesky line
```
2023-10-18 05:18:42,304 - INFO save_manager: Retrieving saves from from /JKSV to Saves/Xance/JKSV
2023-10-18 05:18:47,620 - DEBUG save_manager: Downloaded file /JKSV/Animal Crossing  New Horizons/Device - 2023.10.17 @ 23.34.16/main.dat is empty.
2023-10-18 05:20:21,342 - DEBUG save_manager: Downloaded file /JKSV/log.txt is empty.
2023-10-18 05:20:21,342 - INFO save_manager: Retrieved 300 saves in 99.038s - from /JKSV to Saves/Xance/JKSV
```
