### PR TITLE
use production server & display what is missing on hover

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -386,4 +386,5 @@ if __name__ == '__main__':
     logger.info('Starting initialization of Ownfoil...')
     init()
     logger.info('Initialization steps done, starting server...')
-    app.run(debug=False, host="0.0.0.0", port=8465)
+    from waitress import serve
+    serve(app, host="127.0.0.1", port=8465)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -189,12 +189,12 @@
             tagsContainer.append(typeBadge);
 
             if (game.has_latest_version !== undefined) {
-                const versionBadge = $('<span class="badge rounded-pill game-tag"></span>').addClass(`text-bg-${game.has_latest_version ? 'success' : 'warning'}`).html(`<i class="bi ${game.has_latest_version ? 'bi-check-circle-fill' : 'bi-arrow-down-circle'}"></i>`);
+                const versionBadge = $(`<span class="badge rounded-pill game-tag" title="v${game.version[game.version.length - 1].version}"></span>`).addClass(`text-bg-${game.has_latest_version ? 'success' : 'warning'}`).html(`<i class="bi ${game.has_latest_version ? 'bi-check-circle-fill' : 'bi-arrow-down-circle'}"></i>`);
                 tagsContainer.append(versionBadge);
             }
 
             if (game.has_all_dlcs !== undefined) {
-                const dlcBadge = $('<span class="badge rounded-pill game-tag"></span>').addClass(`text-bg-${game.has_all_dlcs ? 'success' : 'warning'}`).html('<i class="bi bi-box-seam-fill"></i>');
+                const dlcBadge = $(`<span class="badge rounded-pill game-tag" title="Missing DLC"></span>`).addClass(`text-bg-${game.has_all_dlcs ? 'success' : 'warning'}`).html('<i class="bi bi-box-seam-fill"></i>');
                 tagsContainer.append(dlcBadge);
             }
 
@@ -449,7 +449,6 @@
             gamesFilteredByUpdate = []
             gamesFilteredByCompletion = []
 
-            console.log(activeTypeFilters);
             if (activeTypeFilters.size > 0) {
                 filteredGames = [];
                 for (let type of activeTypeFilters) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ requests==2.32.3
 unzip_http==0.6
 watchdog==4.0.2
 Werkzeug==3.0.3
+waitress==3.0.0
 
 # NSTools
 zstandard


### PR DESCRIPTION
When you start ownfoil you get a warning that you need to use a production server for better performance.
So lets use waitress for this.

Also when you filter games by missing updates it is good to know what version is latest so you can add it to your library.