### PR TITLE
feat: add Scheduler to execute periodic tasks in the background

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -64,7 +64,14 @@ def init():
         global is_titledb_update_running
         with titledb_update_lock:
             if is_titledb_update_running:
-                logger.info("Skipping scheduled library scan: update_titledb job is currently in progress.")
+                logger.info("Skipping scheduled library scan: update_titledb job is currently in progress. Rescheduling in 5 minutes.")
+                # Reschedule the job for 5 minutes later
+                app.scheduler.add_job(
+                    job_id=f'scan_library_rescheduled_{datetime.now().timestamp()}', # Unique ID
+                    func=scan_library_job,
+                    run_once=True,
+                    start_date=datetime.now() + timedelta(minutes=5)
+                )
                 return
         logger.info("Starting scheduled library scan job...")
         try:

--- a/app/app.py
+++ b/app/app.py
@@ -70,7 +70,7 @@ def init():
                     job_id=f'scan_library_rescheduled_{datetime.now().timestamp()}', # Unique ID
                     func=scan_library_job,
                     run_once=True,
-                    start_date=datetime.now() + timedelta(minutes=5)
+                    start_date=datetime.now().replace(microsecond=0) + timedelta(minutes=5)
                 )
                 return
         logger.info("Starting scheduled library scan job...")
@@ -80,34 +80,19 @@ def init():
         except Exception as e:
             logger.error(f"Error during scheduled library scan job: {e}")
 
-    # Initial setup job: run update_titledb then scan_library once on startup
-    def initial_setup_job():
-        logger.info("Running initial setup job (TitleDB update and library scan)...")
+    # Update job: run update_titledb then scan_library once on startup
+    def update_db_and_scan_job():
+        logger.info("Running update job (TitleDB update and library scan)...")
         update_titledb_job() # This will set/reset the flag
         scan_library_job() # This will check the flag and run if update_titledb_job is done
-        logger.info("Initial setup job completed.")
+        logger.info("Update job completed.")
 
-    # Schedule the initial setup job to run immediately and only once
+    # Schedule the update job to run immediately and only once
     app.scheduler.add_job(
-        job_id='initial_setup',
-        func=initial_setup_job,
-        run_once=True
-    )
-    
-    # Schedule recurring update_titledb job
-    app.scheduler.add_job(
-        job_id='update_titledb',
-        func=update_titledb_job,
-        interval=timedelta(hours=4),
-        run_first=False # First run after the initial interval
-    )
-
-    # Schedule recurring scan_library job
-    app.scheduler.add_job(
-        job_id='scan_library_daily',
-        func=scan_library_job,
-        interval=timedelta(hours=24),
-        run_first=False # First run after the initial interval
+        job_id='update_db_and_scan',
+        func=update_db_and_scan_job,
+        interval=timedelta(hours=2),
+        run_first=True
     )
 
 os.makedirs(CONFIG_DIR, exist_ok=True)

--- a/app/db.py
+++ b/app/db.py
@@ -186,7 +186,6 @@ def update_file_path(library, old_path, new_path):
         file_entry.filename = filename
         file_entry.filepath = new_path
         file_entry.folder = new_folder
-        file_entry.library = library
         
         # Commit the changes to the database
         db.session.commit()

--- a/app/library.py
+++ b/app/library.py
@@ -96,7 +96,6 @@ def add_files_to_library(library, files):
         file = filepath.replace(library_path, "")
         logger.info(f'Getting file info ({n+1}/{nb_to_identify}): {file}')
 
-        # file_info = identify_file(filepath)
         file_info = get_file_info(filepath)
 
         if file_info is None:
@@ -439,7 +438,6 @@ def generate_library():
     if is_library_unchanged():
         saved_library = load_library_from_disk()
         if saved_library:
-            logger.info("Library hasn't changed since last generate. Returning saved library.")
             return saved_library['library']
     
     logger.info(f'Generating library ...')

--- a/app/library.py
+++ b/app/library.py
@@ -303,7 +303,28 @@ def add_missing_apps_to_db():
     db.session.commit()
     logger.info(f'Finished adding missing apps to database. Total apps added: {apps_added}')
 
-
+def process_library_identification(app, app_settings, target_library_path=None):
+    logger.info(f"Starting library identification process for {target_library_path if target_library_path else 'all libraries'}...")
+    try:
+        with app.app_context():
+            load_titledb(app_settings)
+            
+            if target_library_path:
+                identify_library_files(target_library_path)
+            else:
+                libraries = get_libraries()
+                for library in libraries:
+                    identify_library_files(library.path)
+            
+            add_missing_apps_to_db()
+            update_titles() # Ensure titles are updated after identification
+            generate_library()
+        
+    except Exception as e:
+        logger.error(f"Error during library identification process: {e}")
+    finally:
+        unload_titledb()
+    logger.info(f"Library identification process for {target_library_path if target_library_path else 'all libraries'} completed.")
 
 def update_titles():
     # Remove titles that no longer have any owned apps

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,0 +1,168 @@
+import threading
+import time
+import logging
+from datetime import datetime, timedelta
+from typing import Callable, Dict, Any, Optional, List
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from flask import Flask
+from croniter import croniter, CroniterBadCronError
+
+logger = logging.getLogger('main')
+
+class JobScheduler:
+    def __init__(self, app: Flask, max_workers: int = 4):
+        self.app = app
+        self._lock = threading.RLock()
+        self.scheduled_jobs: Dict[str, Dict[str, Any]] = {}
+        self.executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._running = True
+        self._sleep_time = 1  # seconds
+        self.thread = threading.Thread(target=self._run_loop, daemon=True)
+        self.thread.start()
+        logger.info("Job scheduler initialized.")
+
+    def _run_loop(self):
+        with self.app.app_context():
+            logger.debug("Scheduler loop started.")
+            try:
+                self._check_jobs()
+            except Exception as e:
+                logger.error(f"Initial scheduler check failed: {e}")
+            while self._running:
+                try:
+                    self._check_jobs()
+                except Exception as e:
+                    logger.error(f"Scheduler loop error: {str(e)}")
+                time.sleep(self._sleep_time)
+            logger.info("Scheduler loop exited.")
+
+    def _check_jobs(self):
+        now = datetime.now()
+        with self._lock:
+            for job_id, job in list(self.scheduled_jobs.items()):
+                if job['next_run'] <= now:
+                    self._execute_job(job)
+                    self._reschedule(job)
+
+    def _execute_job(self, job: Dict[str, Any]):
+        def job_wrapper():
+            with self.app.app_context():
+                try:
+                    logger.info(f"Starting job {job['id']}")
+                    job['func'](*job.get('args', []), **job.get('kwargs', {}))
+                    with self._lock:
+                        job['last_run'] = datetime.now()
+                        job['last_error'] = None
+                    logger.info(f"Completed job {job['id']}. Next run at {job['next_run']}")
+                except Exception as e:
+                    with self._lock:
+                        job['last_error'] = str(e)
+                    logger.error(f"Job {job['id']} failed: {e}. Next run at {job['next_run']}")
+
+        self.executor.submit(job_wrapper)
+
+    def _reschedule(self, job: Dict[str, Any]):
+        if job.get('run_once'):
+            with self._lock:
+                del self.scheduled_jobs[job['id']]
+                logger.info(f"Job {job['id']} completed and removed (one-off).")
+        else:
+            now = datetime.now()
+            if job['interval']:
+                job['next_run'] = now + job['interval']
+            elif job['cron']:
+                job['next_run'] = self._next_cron(job['cron'])
+
+    def _next_cron(self, cron_expr: str) -> datetime:
+        try:
+            base = datetime.now()
+            return croniter(cron_expr, base).get_next(datetime)
+        except CroniterBadCronError:
+            raise ValueError(f"Invalid cron expression: {cron_expr}")
+
+    def add_job(
+        self,
+        job_id: str,
+        func: Callable,
+        cron: Optional[str] = None,
+        interval: Optional[timedelta] = None,
+        args: tuple = (),
+        kwargs: Optional[Dict[str, Any]] = None,
+        run_once: bool = False
+    ):
+        with self._lock:
+            if job_id in self.scheduled_jobs:
+                raise ValueError(f"Job {job_id} already exists.")
+
+            if not (cron or interval or run_once):
+                raise ValueError("Must provide either cron, interval, or run_once=True.")
+
+            if cron:
+                next_run = self._next_cron(cron)
+            elif interval:
+                next_run = datetime.now()
+            else:
+                next_run = datetime.now()
+
+            self.scheduled_jobs[job_id] = {
+                'id': job_id,
+                'func': func,
+                'cron': cron,
+                'interval': interval,
+                'args': args,
+                'kwargs': kwargs or {},
+                'next_run': next_run,
+                'run_once': run_once,
+                'last_run': None,
+                'last_error': None
+            }
+
+            schedule_info = f"cron: {cron}" if cron else f"interval: {interval}" if interval else "one-off"
+            logger.info(f"Added job {job_id} with schedule: {schedule_info}, first run at {next_run}")
+
+    def remove_job(self, job_id: str):
+        with self._lock:
+            if job_id in self.scheduled_jobs:
+                del self.scheduled_jobs[job_id]
+                logger.info(f"Removed job {job_id}.")
+
+    def shutdown(self):
+        self._running = False
+        self.executor.shutdown(wait=False)
+        logger.debug("Job scheduler shutdown.")
+
+def init_scheduler(app: Flask):
+    app.scheduler = JobScheduler(app)
+
+# Generic parallel runner
+def run_task_parallel(
+    inputs: List[Any],
+    func: Callable[[Any], Any],
+    max_threads: int = 4,
+    app: Optional[Flask] = None
+):
+    """
+    Run a task in parallel across a list of inputs.
+    Each thread will call `func(item)`.
+
+    - If `app` is provided, runs each task inside `app.app_context()`.
+    - Logs errors individually.
+    """
+    results = []
+    def wrapper(input_item):
+        try:
+            if app:
+                with app.app_context():
+                    return func(input_item)
+            else:
+                return func(input_item)
+        except Exception as e:
+            logger.error(f"Error processing {input_item}: {e}")
+            return None
+
+    with ThreadPoolExecutor(max_threads) as executor:
+        futures = [executor.submit(wrapper, item) for item in inputs]
+        for f in as_completed(futures):
+            results.append(f.result())
+
+    return results

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -91,7 +91,8 @@ class JobScheduler:
         args: tuple = (),
         kwargs: Optional[Dict[str, Any]] = None,
         run_once: bool = False,
-        run_first: bool = False # New parameter
+        run_first: bool = False,
+        start_date: Optional[datetime] = None # for delayed one-off jobs
     ):
         with self._lock:
             if job_id in self.scheduled_jobs:
@@ -100,7 +101,12 @@ class JobScheduler:
             if not (cron or interval or run_once):
                 raise ValueError("Must provide either cron, interval, or run_once=True.")
 
-            if run_once or run_first: # If run_once or run_first is True, execute immediately
+            if run_once:
+                if start_date:
+                    next_run = start_date
+                else:
+                    next_run = datetime.now()
+            elif run_first: # If run_first is True, execute immediately
                 next_run = datetime.now()
             elif cron:
                 next_run = self._next_cron(cron)
@@ -108,7 +114,7 @@ class JobScheduler:
                 next_run = datetime.now() + interval # Run after the first interval
             else:
                 # This case should ideally not be reached due to the initial check
-                next_run = datetime.now() 
+                next_run = datetime.now()
 
             self.scheduled_jobs[job_id] = {
                 'id': job_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+croniter==6.0.0
 flask==3.1.1
 Flask-Login==0.6.3
 Flask-Migrate==4.1.0


### PR DESCRIPTION
The Scheduler allows to process tasks in an asynchronous way, in background threads, to prevent blocking the main loop and potentially crashing the whole app.

Tasks can be scheduled to run periodically. This first iteration includes updating Title DB and scanning the library on startup and then every 2 hours. This feature is required to be able to implement future features like organizing files in the background, verifying file integrity, compressing files...

Additionally there is a performance improvement: before the whole content of Title DB would be stored in memory, meaning the main process would have a large amount or ram used, and now the content is loaded only when used during file identification, and then unloaded.