### PR TITLE
fix(library): fix library not showing in the UI if cached file is corruped

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -450,7 +450,7 @@ def serve_game(id):
 @debounce(10)
 def post_library_change():
     with app.app_context():
-        load_titledb(app_settings)
+        titles.load_titledb()
         process_library_identification(app)
         add_missing_apps_to_db()
         update_titles() # Ensure titles are updated after identification
@@ -460,7 +460,7 @@ def post_library_change():
         # So, we just need to ensure titles_library is updated from the generated library
         generate_library()
         titles.identification_in_progress_count -= 1
-        unload_titledb()
+        titles.unload_titledb()
 
 @app.post('/api/library/scan')
 @access_required('admin')


### PR DESCRIPTION
In #210 the library cache file got corrupted and could not be loaded. Ownfoil did not detect that the file is not valid, so the user is stuck with this corrupted file and the library is not showing in the UI.

This fix ensures atomic writes of the library file, meaning that race condition are prevented, and if the app crashes while writing the original file will be intact.  
Ownfoil now detects if the cached file is corrupted and will generate the library again if so.