### PR TITLE
Migrate from NSTools to nsz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-alpine
 
 # Install platform-specific build dependencies
 ARG TARGETPLATFORM
-RUN apk update && apk add --no-cache bash sudo \
+RUN apk update && apk add --no-cache bash sudo git \
     && if [ "$TARGETPLATFORM" = "linux/arm/v6" ] || [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
         apk add --no-cache build-base gcc musl-dev jpeg-dev zlib-dev libffi-dev cairo-dev pango-dev gdk-pixbuf-dev; \
     fi

--- a/app/settings.py
+++ b/app/settings.py
@@ -3,7 +3,7 @@ from utils import *
 import yaml
 import os, sys
 
-from nstools.nut import Keys
+from nsz.nut import Keys
 
 import logging
 

--- a/app/titles.py
+++ b/app/titles.py
@@ -11,9 +11,8 @@ from pathlib import Path
 from binascii import hexlify as hx, unhexlify as uhx
 import logging
 
-from nstools.Fs import Pfs0, Nca, Type, factory
-from nstools.lib import FsTools
-from nstools.nut import Keys
+from nsz.Fs import Pfs0, Xci, Nsp, Nca, Type, factory
+from nsz.nut import Keys
 
 # Retrieve main logger
 logger = logging.getLogger('main')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ flask==3.1.2
 Flask-Login==0.6.3
 Flask-Migrate==4.1.0
 flask-sqlalchemy==3.1.1
-nstools==1.2.3
+git+https://github.com/a1ex4/nsz.git@library-improvements
 PyYAML==6.0.2
 requests==2.32.5
 unzip_http==0.6


### PR DESCRIPTION
Migrate backend from using https://github.com/seiya-dev/NSTools to https://github.com/nicoboss/nsz as `nsz` is updated more frequently and has a big community around the project. Also has more flexible arguments for compression/decompression tasks.

Currently the missing features from NSTools are pending a merge/release in `nsz` (see https://github.com/nicoboss/nsz/pull/212), in the meantime my custom fork is install with `pip git install`.