### PR TITLE
feat: Added owned/missing badge

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -212,6 +212,12 @@
             const typeBadge = $(`<span class="badge rounded-pill ${typeBadgeClass} game-tag"></span>`).text(game.app_type);
             tagsContainer.append(typeBadge);
 
+            // Add owned/missing tag
+            const ownedBadgeClass = game.owned ? 'text-bg-success' : 'text-bg-danger';
+            const ownedText = game.owned ? 'Owned' : 'Missing';
+            const ownedBadge = $(`<span class="badge rounded-pill ${ownedBadgeClass} game-tag"></span>`).text(ownedText);
+            tagsContainer.append(ownedBadge);
+
             if (game.has_latest_version !== undefined) {
                 const versionBadge = $(`<span class="badge rounded-pill game-tag version-tag" title="${game.name} [${game.title_id}] Updates"></span>`)
                     .addClass(`text-bg-${game.has_latest_version ? 'success' : 'warning'}`)


### PR DESCRIPTION
I added one more badge to the grid because I didn't understand why a lot of games appears in the grid. I realized that some algorithms write in db all the games related to the owned game... and the badge changes color but I think is better with a new badge...

Perhaps you don't like this change. I will understand hahahaha