### PR TITLE
improv(organizer): add option to enforce Windows filename sanitizing

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -31,6 +31,7 @@ DEFAULT_SETTINGS = {
             "organizer": {
                 "enabled": False,
                 "remove_empty_folders": False,
+                "windows_compatible": False,
                 "templates": {
                     "base": "{titleName}/{titleName} [{appId}][v{appVersion}]",
                     "update": "{titleName}/{titleName} [{appId}][v{appVersion}]",

--- a/app/library.py
+++ b/app/library.py
@@ -11,11 +11,11 @@ from utils import *
 from settings import load_settings
 from db import update_file_path 
 
-def sanitize_filename(name):
-    if sys.platform == 'win32':
+def sanitize_filename(name, windows_compatible=False):
+    if sys.platform == 'win32' or windows_compatible:
         forbidden_chars = FORBIDDEN_CHARS_WINDOWS
         # Replace forbidden characters with underscore
-        sanitized = ''.join('_' if c in forbidden_chars else c for c in name)
+        sanitized = ''.join('' if c in forbidden_chars else c for c in name)
         # Remove trailing periods and spaces specific to Windows
         sanitized = sanitized.strip().rstrip('. ')
         # Handle Windows reserved names
@@ -67,7 +67,8 @@ def organize_file(file_obj, library_path, organizer_settings, watcher):
         
         # Format the new relative path and remove leading slash if present
         raw_path = template.format(**format_data).lstrip('/')
-        safe_parts = [sanitize_filename(part) for part in Path(raw_path).parts]
+        windows_compatible = organizer_settings.get('windows_compatible', False)
+        safe_parts = [sanitize_filename(part, windows_compatible) for part in Path(raw_path).parts]
         new_relative_path = os.path.join(*safe_parts)
         
         # Construct the full new path

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -214,15 +214,25 @@
 
                 <h4 class="py-2">Organizer</h4>
                 <p>Keep your library organized.</p>
-                <div class="mb-3 form-check">
-                    <input type="checkbox" class="form-check-input" id="organizerEnabledCheck">
-                    <label class="form-check-label" for="organizerEnabledCheck">Enable organizer</label>
-                    <div class="form-text">Enables automatic organization of identified files in the library, according to the templates below.</div>
-                </div>
-                <div class="mb-3 form-check">
-                    <input type="checkbox" class="form-check-input" id="removeEmptyFoldersCheck">
-                    <label class="form-check-label" for="removeEmptyFoldersCheck">Remove empty folders</label>
-                    <div class="form-text">Removes empty folders after organizing files.</div>
+                <div class="row">
+                    <div class="col-7">
+                        <div class="mb-3 form-check">
+                            <input type="checkbox" class="form-check-input" id="organizerEnabledCheck">
+                            <label class="form-check-label" for="organizerEnabledCheck">Enable organizer</label>
+                            <div class="form-text">Enables automatic organization of identified files in the library, according to the templates below.</div>
+                        </div>
+                        <div class="mb-3 form-check">
+                            <input type="checkbox" class="form-check-input" id="removeEmptyFoldersCheck">
+                            <label class="form-check-label" for="removeEmptyFoldersCheck">Remove empty folders</label>
+                            <div class="form-text">Removes empty folders after organizing files.</div>
+                        </div>
+                        <div class="mb-3 form-check">
+                            <input type="checkbox" class="form-check-input" id="windowsCompatibleCheck">
+                            <label class="form-check-label" for="windowsCompatibleCheck">Windows compatible filenames</label>
+                            <div class="form-text">Ownfoil enforces filename sanitization depending on the OS running it. Enabling this will sanitize filenames with
+                                Windows compatible characters, this is needed when acessing libraries from Windows systems (e.g. SMB/NFS mount).</div>
+                        </div>
+                    </div>
                 </div>
 
                 <h5 class="pb-3 pt-2">Templates</h5>
@@ -981,6 +991,7 @@
             organizer: {
                 enabled: getCheckboxStatus("organizerEnabledCheck"),
                 remove_empty_folders: getCheckboxStatus("removeEmptyFoldersCheck"),
+                windows_compatible: getCheckboxStatus("windowsCompatibleCheck"),
                 templates: {
                     base: getInputVal("baseTemplateInput"),
                     update: getInputVal("updateTemplateInput"),
@@ -1092,6 +1103,7 @@
             $("#deleteOlderUpdatesCheck").prop("checked", librarySettings['management']['delete_older_updates']);
             $("#organizerEnabledCheck").prop("checked", librarySettings['management']['organizer']['enabled']);
             $("#removeEmptyFoldersCheck").prop("checked", librarySettings['management']['organizer']['remove_empty_folders']);
+            $("#windowsCompatibleCheck").prop("checked", librarySettings['management']['organizer']['windows_compatible']);
             setInputVal("baseTemplateInput", librarySettings['management']['organizer']['templates']['base']);
             setInputVal("updateTemplateInput", librarySettings['management']['organizer']['templates']['update']);
             setInputVal("dlcTemplateInput", librarySettings['management']['organizer']['templates']['dlc']);


### PR DESCRIPTION
Ownfoil enforces filename sanitization depending on the OS running it. Enabling this will sanitize filenames with Windows compatible characters, this is needed when acessing libraries from Windows systems (e.g. SMB/NFS mount).

Related to #251 and #284 