### PR TITLE
Improve handling of unidentified files

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -81,6 +81,7 @@ class Files(db.Model):
     identification_error = db.Column(db.String)
     identification_attempts = db.Column(db.Integer, default=0)
     last_attempt = db.Column(db.DateTime, default=datetime.datetime.now())
+    mtime = db.Column(db.Float)
 
     library = db.relationship('Libraries', backref=db.backref('files', lazy=True, cascade="all, delete-orphan"))
 
@@ -268,7 +269,9 @@ def get_all_apps():
     return apps_list
 
 def get_all_non_identified_files_from_library(library_id):
-    return Files.query.filter_by(identified=False, library_id=library_id).all()
+    return Files.query.filter_by(
+        identified=False, library_id=library_id, identification_attempts=0
+    ).all()
 
 def get_files_with_identification_from_library(library_id, identification_type):
     return Files.query.filter_by(library_id=library_id, identification_type=identification_type).all()
@@ -378,6 +381,15 @@ def add_file_to_app(app_id, app_version, file_id):
                 db.session.rollback()
             return True
     return False
+
+def reset_file_identification(file):
+    """Clear identification state on a Files row so it will be re-identified."""
+    file.identified = False
+    file.identification_error = None
+    file.identification_type = None
+    file.identification_attempts = 0
+    file.nb_content = 0
+    file.multicontent = False
 
 def remove_file_from_apps(file_id):
     """Remove a file from all apps that reference it and update owned status"""

--- a/app/migrations/versions/a1b2c3d4e5f6_add_tasks_and_ignored_events.py
+++ b/app/migrations/versions/a1b2c3d4e5f6_add_tasks_and_ignored_events.py
@@ -44,8 +44,18 @@ def upgrade():
         sa.PrimaryKeyConstraint('id'),
     )
 
+    op.add_column('files', sa.Column('mtime', sa.Float(), nullable=True))
+
+    # Give previously-failed identifications a fresh shot now that the
+    # identify pipeline will skip files with attempts > 0.
+    op.execute(
+        "UPDATE files SET identification_attempts = 0 "
+        "WHERE identified = 0 AND identification_error IS NOT NULL"
+    )
+
 
 def downgrade():
+    op.drop_column('files', 'mtime')
     op.drop_table('ignored_events')
     op.drop_index('ix_tasks_parent_id', table_name='tasks')
     op.drop_index('ix_tasks_status_created', table_name='tasks')

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -13,7 +13,7 @@ from db import (
     get_libraries, add_title_id_in_db, get_title_id_db_id, add_file_to_app,
     file_exists_in_db, update_file_path, delete_file_by_filepath,
     set_library_scan_time, remove_missing_files_from_db,
-    remove_file_from_apps,
+    remove_file_from_apps, reset_file_identification,
 )
 from settings import get_settings
 from utils import interval_string_to_timedelta, delete_empty_folders
@@ -389,6 +389,7 @@ def add_file_task(library_path, filepath, **kwargs):
         filename=file_info["filename"],
         extension=file_info["extension"],
         size=file_info["size"],
+        mtime=file_info["mtime"],
     )
     db.session.add(new_file)
     db.session.commit()
@@ -610,8 +611,27 @@ def generate_library_task(**kwargs):
 
 # --- Watcher event handlers ---
 @register_task('handle_file_added')
+@_schedules_generate_library
 def handle_file_added_task(library_path, filepath, **kwargs):
-    enqueue_task('add_file', {'library_path': library_path, 'filepath': filepath})
+    file = Files.query.filter_by(filepath=filepath).first()
+    if file is None:
+        enqueue_task('add_file', {'library_path': library_path, 'filepath': filepath})
+        return
+
+    new_size = titles_lib.get_file_size(filepath)
+    new_mtime = os.path.getmtime(filepath)
+    if file.size == new_size and file.mtime == new_mtime:
+        return
+
+    logger.info(f'File changed on disk, re-identifying: {file.filename}')
+    remove_file_from_apps(file.id)
+    file.size = new_size
+    file.mtime = new_mtime
+    reset_file_identification(file)
+    db.session.commit()
+    enqueue_or_child('identify_file', {'filepath': filepath, 'file_id': file.id})
+    if _current_task_id is not None:
+        set_waiting_for_children()
 
 
 @register_task('handle_file_moved')

--- a/app/titles.py
+++ b/app/titles.py
@@ -80,6 +80,7 @@ def get_file_info(filepath):
         'extension': extension,
         'compressed': compressed,
         'size': get_file_size(filepath),
+        'mtime': os.path.getmtime(filepath),
     }
 
 def identify_appId(app_id):


### PR DESCRIPTION
Follows improvements from dbd8c549cdd25522e370e1e038ad23b83e09b8f7
  - identify_library no longer reattempts files that have already been tried
  - Added mtime to Files so the watcher's modified event can detect real content changes to flag file for re identification
  - resets identification_attempts on previously-failed rows so they get one fresh shot after upgrade.