### PR TITLE
Store TitleDB in sql database

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -18,6 +18,7 @@ from utils import *
 from library import *
 import json
 import tasks as tasks_mod
+import titledb_store
 import os
 from clients import CyberFoilClient, TinfoilClient, SphairaClient
 
@@ -435,6 +436,35 @@ def upload_file():
         resp['data']['corrupt_keys'] = corrupt_keys
 
     return jsonify(resp)
+
+
+@app.get('/api/titledb/custom')
+@access_required('admin')
+def list_custom_titles_api():
+    return jsonify({'success': True, 'entries': titledb_store.list_custom_titles()})
+
+
+@app.post('/api/titledb/custom')
+@access_required('admin')
+def add_custom_title_api():
+    data = request.json or {}
+    title_id = data.get('id')
+    if not title_id:
+        return jsonify({'success': False, 'errors': [{'path': 'id', 'error': 'id is required'}]}), 400
+    ok, err = titledb_store.add_custom_title(data)
+    if not ok:
+        return jsonify({'success': False, 'errors': [{'path': 'id', 'error': err}]}), 400
+    tasks_mod.enqueue_task('identify_library')
+    return jsonify({'success': True, 'errors': []}), 201
+
+
+@app.delete('/api/titledb/custom/<title_id>')
+@access_required('admin')
+def delete_custom_title_api(title_id):
+    ok, err = titledb_store.delete_custom_title(title_id)
+    if not ok:
+        return jsonify({'success': False, 'errors': [{'path': 'id', 'error': err}]}), 404
+    return jsonify({'success': True, 'errors': []})
 
 
 @app.route('/api/titles', methods=['GET'])

--- a/app/constants.py
+++ b/app/constants.py
@@ -19,7 +19,8 @@ TITLEDB_DEFAULT_FILES = [
     'versions.txt',
     'languages.json',
 ]
-
+TITLES_DB_FILE = os.path.join(CONFIG_DIR, 'titles.db')
+CUSTOM_TITLES_FILE = os.path.join(CONFIG_DIR, 'custom_titles.json')
 OWNFOIL_DB = 'sqlite:///' + DB_FILE
 
 DEFAULT_SETTINGS = {

--- a/app/library.py
+++ b/app/library.py
@@ -470,7 +470,6 @@ def generate_library():
             return saved_library['library']
     
     logger.info(f'Generating library ...')
-    titles_lib.load_titledb()
     titles = get_all_apps()
     games_info = []
     processed_dlc_apps = set()  # Track processed DLC app_ids to avoid duplicates
@@ -575,9 +574,6 @@ def generate_library():
     }
 
     save_library_to_disk(library_data)
-
-    titles_lib.identification_in_progress_count -= 1
-    titles_lib.unload_titledb()
 
     logger.info(f'Generating library done.')
 

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -308,19 +308,6 @@ def _schedules_generate_library(func):
     return wrapper
 
 
-def _with_titledb(func):
-    """Decorator: load titledb before func runs, release after."""
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        titles_lib.load_titledb()
-        try:
-            return func(*args, **kwargs)
-        finally:
-            titles_lib.identification_in_progress_count -= 1
-            titles_lib.unload_titledb()
-    return wrapper
-
-
 # --- Periodic tasks ---
 @register_task('update_titledb')
 def update_titledb_task(**kwargs):
@@ -328,6 +315,8 @@ def update_titledb_task(**kwargs):
     titledb.update_titledb(settings)
     for lib in get_libraries():
         enqueue_task('scan_library', {'library_path': lib.path})
+    # Re-identify any files that could now be matched with fresh metadata
+    enqueue_task('identify_library')
     # After titledb update, existing titles may have new DLC/update versions
     enqueue_task('add_missing_apps')
     # Re-enqueue for next scheduled run
@@ -432,7 +421,6 @@ def _identify_library_done(**kwargs):
 
 @register_task('identify_file')
 @_schedules_generate_library
-@_with_titledb
 def identify_file_task(filepath, file_id, **kwargs):
     """Identify a single file, upsert its Apps/Titles, then enqueue add_missing_apps_for_title."""
     identified_title_ids = []
@@ -505,7 +493,6 @@ def identify_file_task(filepath, file_id, **kwargs):
 
 @register_task('add_missing_apps_for_title')
 @_schedules_generate_library
-@_with_titledb
 def add_missing_apps_for_title_task(title_id, **kwargs):
     """Per-title: expand missing base/update/DLC apps for one title, then enqueue update_titles_for_title."""
     add_missing_apps_for_title(title_id)
@@ -552,7 +539,6 @@ def _organize_library_done(**kwargs):
 
 @register_task('organize_file')
 @_schedules_generate_library
-@_with_titledb
 def organize_file_task(file_id, **kwargs):
     """Organize a single file."""
     file_obj = db.session.get(Files, file_id)
@@ -568,7 +554,7 @@ def remove_outdated_updates_task(**kwargs):
     """Remove outdated update files."""
     app_settings = get_settings()
     if app_settings['library']['management']['delete_older_updates']:
-        _with_titledb(remove_outdated_update_files)()
+        remove_outdated_update_files()
 
 
 # --- Batch maintenance ---
@@ -576,7 +562,7 @@ def remove_outdated_updates_task(**kwargs):
 @_schedules_generate_library
 def add_missing_apps_task(**kwargs):
     """Batch: expand missing apps for every title. Used post-titledb-update."""
-    _with_titledb(add_missing_apps_to_db)()
+    add_missing_apps_to_db()
     enqueue_task('update_titles')
 
 

--- a/app/titledb.py
+++ b/app/titledb.py
@@ -58,15 +58,16 @@ def download_titledb_files(rzf, files):
 
 
 def update_titledb_files(app_settings):
+    """Download changed titledb files. Returns the list of files written."""
     files_to_update = []
-    
+
     region_titles_file = get_region_titles_file(app_settings)
     region_titles_file_present = region_titles_file in os.listdir(TITLEDB_DIR)
 
     r = requests.get(TITLEDB_ARTEFACTS_URL, allow_redirects = False)
     direct_url = r.next.url
     rzf = unzip_http.RemoteZipFile(direct_url)
-    
+
     if is_titledb_update_available(rzf):
         files_to_update = TITLEDB_DEFAULT_FILES + [region_titles_file]
         old_region_titles_files = [f for f in os.listdir(TITLEDB_DIR) if re.match(r"titles\.[A-Z]{2}\.[a-z]{2}\.json", f) and f not in files_to_update]
@@ -77,12 +78,19 @@ def update_titledb_files(app_settings):
 
     if len(files_to_update):
         download_titledb_files(rzf, files_to_update)
+    return files_to_update
 
 
 def update_titledb(app_settings):
+    """Download titledb JSON updates and (re)build titles.db if anything changed."""
+    import titledb_store  # local import to avoid circular import
     logger.info('Updating titledb...')
     if not os.path.isdir(TITLEDB_DIR):
         os.makedirs(TITLEDB_DIR, exist_ok=True)
 
-    update_titledb_files(app_settings)
+    downloaded = update_titledb_files(app_settings)
+    current_locale = f"{app_settings['titles']['region']}.{app_settings['titles']['language']}"
+    imported_locale = titledb_store.get_imported_locale()
+    if downloaded or imported_locale != current_locale:
+        titledb_store.import_from_json(app_settings)
     logger.info('titledb update done.')

--- a/app/titledb_store.py
+++ b/app/titledb_store.py
@@ -1,0 +1,517 @@
+"""SQLite-backed store for titledb JSON data.
+
+Replaces the in-memory TitleDB loaded from JSON files with a disposable
+SQLite database (``config/titles.db``) built from the downloaded JSON files.
+Custom admin-added entries are persisted separately in
+``config/custom_titles.json`` and merged into the DB on every rebuild.
+"""
+import contextlib
+import json
+import logging
+import os
+import sqlite3
+
+from constants import TITLEDB_DIR, TITLES_DB_FILE, CUSTOM_TITLES_FILE
+import titledb
+
+logger = logging.getLogger('main')
+
+SOURCE_UPSTREAM = 'upstream'
+SOURCE_CUSTOM = 'custom'
+
+# Columns for the titles table. (json_key, column_name, json_type)
+#   json_type: 's'=scalar (stored as-is), 'j'=list/object (json-encoded)
+_TITLES_COLUMNS = [
+    ('id',                'id',                's'),
+    ('name',              'name',              's'),
+    ('bannerUrl',         'banner_url',        's'),
+    ('iconUrl',           'icon_url',          's'),
+    ('frontBoxArt',       'front_box_art',     's'),
+    ('description',       'description',       's'),
+    ('intro',             'intro',             's'),
+    ('developer',         'developer',         's'),
+    ('publisher',         'publisher',         's'),
+    ('releaseDate',       'release_date',      's'),
+    ('category',          'category',          'j'),
+    ('isDemo',            'is_demo',           's'),
+    ('nsuId',             'nsu_id',            's'),
+    ('numberOfPlayers',   'number_of_players', 's'),
+    ('parentId',          'parent_id',         's'),
+    ('rank',              'rank',              's'),
+    ('rating',            'rating',            's'),
+    ('ratingContent',     'rating_content',    'j'),
+    ('region',            'region',            's'),
+    ('regions',           'regions',           'j'),
+    ('languages',         'languages',         'j'),
+    ('language',          'language',          's'),
+    ('rightsId',          'rights_id',         's'),
+    ('screenshots',       'screenshots',       'j'),
+    ('size',              'size',              's'),
+    ('version',           'version',           's'),
+    ('key',               'nca_key',           's'),
+    ('ids',               'ids',               'j'),
+]
+
+_CNMTS_COLUMNS = [
+    # (json_key, column_name, json_type)
+    ('titleId',                    'title_id',                     's'),
+    ('titleType',                  'title_type',                   's'),
+    ('version',                    'version',                      's'),
+    ('otherApplicationId',         'other_application_id',         's'),
+    ('requiredApplicationVersion', 'required_application_version', 's'),
+    ('requiredSystemVersion',      'required_system_version',      's'),
+    ('contentEntries',             'content_entries',              'j'),
+    ('metaEntries',                'meta_entries',                 'j'),
+]
+
+
+def _titles_schema():
+    cols = ',\n    '.join(f'"{c}"' for _, c, _ in _TITLES_COLUMNS if c != 'id')
+    return f'''
+    CREATE TABLE titles (
+        "id" TEXT NOT NULL,
+        source TEXT NOT NULL,
+        {cols},
+        PRIMARY KEY ("id", source)
+    );
+    CREATE INDEX idx_titles_id ON titles("id");
+    '''
+
+
+def _cnmts_schema():
+    cols = ',\n    '.join(f'"{c}"' for _, c, _ in _CNMTS_COLUMNS)
+    return f'''
+    CREATE TABLE cnmts (
+        app_id TEXT NOT NULL,
+        cnmt_version TEXT NOT NULL,
+        {cols},
+        PRIMARY KEY (app_id, cnmt_version)
+    );
+    CREATE INDEX idx_cnmts_app_id     ON cnmts(app_id);
+    CREATE INDEX idx_cnmts_dlc_lookup ON cnmts(other_application_id, title_type);
+    '''
+
+
+_SCHEMA = _titles_schema() + _cnmts_schema() + '''
+CREATE TABLE versions (
+    title_id     TEXT NOT NULL,
+    version      INTEGER NOT NULL,
+    release_date TEXT,
+    PRIMARY KEY (title_id, version)
+);
+
+CREATE TABLE versions_txt (
+    app_id  TEXT PRIMARY KEY,
+    version TEXT NOT NULL
+);
+
+CREATE TABLE meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT
+);
+'''
+
+
+def _encode_row(record, columns):
+    out = []
+    for json_key, _col, kind in columns:
+        v = record.get(json_key)
+        if kind == 'j' and v is not None:
+            v = json.dumps(v, separators=(',', ':'))
+        out.append(v)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Import
+# ---------------------------------------------------------------------------
+
+def import_from_json(app_settings):
+    """(Re)build ``titles.db`` from the downloaded JSON files in TITLEDB_DIR.
+
+    Builds into a ``titles.db.new`` file and atomically renames it, so any
+    in-flight reader connections keep seeing the old DB until they close.
+    Custom entries are re-imported from ``custom_titles.json`` at the end.
+    """
+    region_file = os.path.join(TITLEDB_DIR, titledb.get_region_titles_file(app_settings))
+    cnmts_file = os.path.join(TITLEDB_DIR, 'cnmts.json')
+    versions_file = os.path.join(TITLEDB_DIR, 'versions.json')
+    versions_txt_file = os.path.join(TITLEDB_DIR, 'versions.txt')
+
+    for path in (region_file, cnmts_file, versions_file, versions_txt_file):
+        if not os.path.isfile(path):
+            logger.warning(f'Cannot build titles.db, missing file: {path}')
+            return
+
+    new_path = TITLES_DB_FILE + '.new'
+    if os.path.exists(new_path):
+        os.remove(new_path)
+
+    logger.info('Building titles.db from titledb JSON files ...')
+    conn = sqlite3.connect(new_path)
+    try:
+        conn.execute('PRAGMA journal_mode=OFF')
+        conn.execute('PRAGMA synchronous=OFF')
+        conn.executescript(_SCHEMA)
+
+        _import_titles(conn, region_file)
+        _import_cnmts(conn, cnmts_file)
+        _import_versions(conn, versions_file)
+        _import_versions_txt(conn, versions_txt_file)
+        _import_customs(conn)
+
+        conn.execute(
+            'INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)',
+            ('imported_locale', f"{app_settings['titles']['region']}.{app_settings['titles']['language']}"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    os.replace(new_path, TITLES_DB_FILE)
+    logger.info('titles.db build complete.')
+
+
+def _import_titles(conn, path):
+    cols = ['"id"', 'source'] + [f'"{c}"' for _, c, _ in _TITLES_COLUMNS if c != 'id']
+    placeholders = ','.join('?' * len(cols))
+    sql = f'INSERT OR IGNORE INTO titles ({",".join(cols)}) VALUES ({placeholders})'
+
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    batch = []
+    count = 0
+    id_col_index = next(i for i, (_, c, _) in enumerate(_TITLES_COLUMNS) if c == 'id')
+    for _key, record in data.items():
+        if not isinstance(record, dict):
+            continue
+        row = _encode_row(record, _TITLES_COLUMNS)
+        if row[id_col_index] is None:
+            continue
+        # Column order: id, source, then remaining titles columns (in _TITLES_COLUMNS order minus id)
+        rest = [v for i, v in enumerate(row) if i != id_col_index]
+        batch.append([row[id_col_index], SOURCE_UPSTREAM] + rest)
+        if len(batch) >= 5000:
+            conn.executemany(sql, batch)
+            count += len(batch)
+            batch.clear()
+    if batch:
+        conn.executemany(sql, batch)
+        count += len(batch)
+    logger.info(f'  titles: {count} rows')
+
+
+def _import_cnmts(conn, path):
+    cols = ['app_id', 'cnmt_version'] + [f'"{c}"' for _, c, _ in _CNMTS_COLUMNS]
+    placeholders = ','.join('?' * len(cols))
+    sql = f'INSERT OR IGNORE INTO cnmts ({",".join(cols)}) VALUES ({placeholders})'
+
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    batch = []
+    count = 0
+    for app_id, versions in data.items():
+        if not isinstance(versions, dict):
+            continue
+        for cnmt_version, record in versions.items():
+            if not isinstance(record, dict):
+                continue
+            row = _encode_row(record, _CNMTS_COLUMNS)
+            batch.append([app_id, cnmt_version] + row)
+            if len(batch) >= 5000:
+                conn.executemany(sql, batch)
+                count += len(batch)
+                batch.clear()
+    if batch:
+        conn.executemany(sql, batch)
+        count += len(batch)
+    logger.info(f'  cnmts: {count} rows')
+
+
+def _import_versions(conn, path):
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    batch = []
+    count = 0
+    for title_id, versions in data.items():
+        if not isinstance(versions, dict):
+            continue
+        for version, release_date in versions.items():
+            try:
+                version_int = int(version)
+            except (TypeError, ValueError):
+                continue
+            batch.append((title_id, version_int, release_date))
+    conn.executemany(
+        'INSERT OR IGNORE INTO versions(title_id, version, release_date) VALUES (?, ?, ?)',
+        batch,
+    )
+    count = len(batch)
+    logger.info(f'  versions: {count} rows')
+
+
+def _import_versions_txt(conn, path):
+    batch = []
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if not line:
+                continue
+            parts = line.split('|')
+            if len(parts) < 3:
+                continue
+            app_id = parts[0]
+            version = parts[2] or '0'
+            batch.append((app_id, version))
+    conn.executemany(
+        'INSERT OR REPLACE INTO versions_txt(app_id, version) VALUES (?, ?)',
+        batch,
+    )
+    logger.info(f'  versions_txt: {len(batch)} rows')
+
+
+def _import_customs(conn):
+    records = _load_custom_titles()
+    if not records:
+        return
+    for record in records.values():
+        _upsert_custom_title(conn, record)
+    logger.info(f'  custom titles: {len(records)} rows')
+
+
+# ---------------------------------------------------------------------------
+# Custom entries
+# ---------------------------------------------------------------------------
+
+def _load_custom_titles():
+    if not os.path.isfile(CUSTOM_TITLES_FILE):
+        return {}
+    try:
+        with open(CUSTOM_TITLES_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except Exception as e:
+        logger.error(f'Failed to load {CUSTOM_TITLES_FILE}: {e}')
+        return {}
+
+
+def _save_custom_titles(records):
+    tmp = CUSTOM_TITLES_FILE + '.tmp'
+    with open(tmp, 'w', encoding='utf-8') as f:
+        json.dump(records, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, CUSTOM_TITLES_FILE)
+
+
+def _upsert_custom_title(conn, record):
+    rec = dict(record)
+    rec.setdefault('id', record.get('id'))
+    cols = ['"id"', 'source'] + [f'"{c}"' for _, c, _ in _TITLES_COLUMNS if c != 'id']
+    placeholders = ','.join('?' * len(cols))
+    sql = f'INSERT OR REPLACE INTO titles ({",".join(cols)}) VALUES ({placeholders})'
+    row = _encode_row(rec, _TITLES_COLUMNS)
+    id_col_index = next(i for i, (_, c, _) in enumerate(_TITLES_COLUMNS) if c == 'id')
+    rest = [v for i, v in enumerate(row) if i != id_col_index]
+    conn.execute(sql, [row[id_col_index], SOURCE_CUSTOM] + rest)
+
+
+def list_custom_titles():
+    return _load_custom_titles()
+
+
+def add_custom_title(record):
+    """Persist a new custom title and upsert it into titles.db. Returns (ok, error)."""
+    title_id = record.get('id')
+    if not title_id:
+        return False, 'id is required'
+    records = _load_custom_titles()
+    if title_id in records:
+        return False, f'Custom entry already exists for {title_id}'
+    records[title_id] = record
+    _save_custom_titles(records)
+
+    if os.path.isfile(TITLES_DB_FILE):
+        with contextlib.closing(sqlite3.connect(TITLES_DB_FILE)) as conn:
+            _upsert_custom_title(conn, record)
+            conn.commit()
+    return True, None
+
+
+def delete_custom_title(title_id):
+    records = _load_custom_titles()
+    if title_id not in records:
+        return False, f'No custom entry for {title_id}'
+    del records[title_id]
+    _save_custom_titles(records)
+
+    if os.path.isfile(TITLES_DB_FILE):
+        with contextlib.closing(sqlite3.connect(TITLES_DB_FILE)) as conn:
+            conn.execute('DELETE FROM titles WHERE "id" = ? AND source = ?', (title_id, SOURCE_CUSTOM))
+            conn.commit()
+    return True, None
+
+
+# ---------------------------------------------------------------------------
+# Query layer
+# ---------------------------------------------------------------------------
+
+def get_imported_locale():
+    """Return the locale string (e.g. 'US.en') stored in titles.db, or None."""
+    if not os.path.isfile(TITLES_DB_FILE):
+        return None
+    try:
+        with contextlib.closing(sqlite3.connect(f'file:{TITLES_DB_FILE}?mode=ro', uri=True)) as conn:
+            row = conn.execute("SELECT value FROM meta WHERE key = 'imported_locale'").fetchone()
+            return row[0] if row else None
+    except sqlite3.Error:
+        return None
+
+
+def _connect_ro():
+    """Read-only connection. Returns None if the DB doesn't exist yet."""
+    if not os.path.isfile(TITLES_DB_FILE):
+        return None
+    uri = f'file:{TITLES_DB_FILE}?mode=ro'
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _decode_row(row, columns):
+    """Turn a sqlite row back into the JSON-shaped dict used by callers."""
+    if row is None:
+        return None
+    out = {}
+    for json_key, col, kind in columns:
+        v = row[col]
+        if kind == 'j' and v is not None:
+            try:
+                v = json.loads(v)
+            except Exception:
+                pass
+        out[json_key] = v
+    return out
+
+
+def get_title_record(title_id):
+    """Full title record (custom preferred over upstream). Returns None if missing."""
+    conn = _connect_ro()
+    if conn is None:
+        return None
+    try:
+        row = conn.execute(
+            'SELECT * FROM titles WHERE "id" = ? '
+            "ORDER BY CASE source WHEN 'custom' THEN 0 ELSE 1 END LIMIT 1",
+            (title_id,),
+        ).fetchone()
+        return _decode_row(row, _TITLES_COLUMNS)
+    finally:
+        conn.close()
+
+
+def get_game_info(title_id):
+    """Compatibility shim returning the subset used by identify/organize code."""
+    rec = get_title_record(title_id)
+    if rec is None:
+        return {
+            'name': 'Unrecognized',
+            'bannerUrl': '//placehold.it/400x200',
+            'iconUrl': '',
+            'id': str(title_id) + ' not found in titledb',
+            'category': '',
+        }
+    return {
+        'name': rec.get('name'),
+        'bannerUrl': rec.get('bannerUrl'),
+        'iconUrl': rec.get('iconUrl'),
+        'id': rec.get('id'),
+        'category': rec.get('category'),
+    }
+
+
+def get_cnmt_latest(app_id):
+    """Return the cnmts record with the highest numeric cnmt_version for app_id."""
+    conn = _connect_ro()
+    if conn is None:
+        return None
+    try:
+        row = conn.execute(
+            'SELECT * FROM cnmts WHERE app_id = ? '
+            'ORDER BY CAST(cnmt_version AS INTEGER) DESC LIMIT 1',
+            (app_id.lower(),),
+        ).fetchone()
+        out = _decode_row(row, _CNMTS_COLUMNS)
+        if out is None:
+            return None
+        out['app_id'] = row['app_id']
+        out['cnmt_version'] = row['cnmt_version']
+        return out
+    finally:
+        conn.close()
+
+
+def get_all_existing_versions(title_id):
+    conn = _connect_ro()
+    if conn is None:
+        return []
+    try:
+        rows = conn.execute(
+            'SELECT version, release_date FROM versions WHERE title_id = ?',
+            (title_id.lower(),),
+        ).fetchall()
+        return [
+            {
+                'version': r['version'],
+                'update_number': int(r['version']) // 65536,
+                'release_date': r['release_date'],
+            }
+            for r in rows
+        ]
+    finally:
+        conn.close()
+
+
+def get_all_app_existing_versions(app_id):
+    conn = _connect_ro()
+    if conn is None:
+        return None
+    try:
+        rows = conn.execute(
+            'SELECT cnmt_version FROM cnmts WHERE app_id = ? ORDER BY cnmt_version',
+            (app_id.lower(),),
+        ).fetchall()
+        if not rows:
+            return None
+        return [r['cnmt_version'] for r in rows]
+    finally:
+        conn.close()
+
+
+def get_app_id_version_from_versions_txt(app_id):
+    conn = _connect_ro()
+    if conn is None:
+        return None
+    try:
+        row = conn.execute(
+            'SELECT version FROM versions_txt WHERE app_id = ?', (app_id,)
+        ).fetchone()
+        return row['version'] if row else None
+    finally:
+        conn.close()
+
+
+def get_all_existing_dlc(title_id):
+    conn = _connect_ro()
+    if conn is None:
+        return []
+    try:
+        rows = conn.execute(
+            'SELECT DISTINCT app_id FROM cnmts WHERE other_application_id = ? AND title_type = 130',
+            (title_id.lower(),),
+        ).fetchall()
+        return [r['app_id'].upper() for r in rows]
+    finally:
+        conn.close()

--- a/app/titles.py
+++ b/app/titles.py
@@ -1,9 +1,9 @@
 import os
 import sys
 import re
-import json
 
 import titledb
+import titledb_store
 from constants import *
 from utils import *
 from settings import *
@@ -22,13 +22,13 @@ Pfs0.Print.silent = True
 app_id_regex = r"\[([0-9A-Fa-f]{16})\]"
 version_regex = r"\[v(\d+)\]"
 
-# Global variables for TitleDB data
-identification_in_progress_count = 0
-_titles_db_loaded = False
-_cnmts_db = None
-_titles_db = None
-_versions_db = None
-_versions_txt_db = None
+# Re-export titledb_store query functions so existing callers
+# (titles_lib.get_game_info, titles_lib.get_all_existing_versions, ...) keep working.
+get_game_info = titledb_store.get_game_info
+get_all_existing_versions = titledb_store.get_all_existing_versions
+get_all_app_existing_versions = titledb_store.get_all_app_existing_versions
+get_app_id_version_from_versions_txt = titledb_store.get_app_id_version_from_versions_txt
+get_all_existing_dlc = titledb_store.get_all_existing_dlc
 
 def getDirsAndFiles(path):
     entries = os.listdir(path)
@@ -85,109 +85,35 @@ def get_file_info(filepath):
 
 def identify_appId(app_id):
     app_id = app_id.lower()
-    
-    global _cnmts_db
-    if _cnmts_db is None:
-        logger.error("cnmts_db is not loaded. Call load_titledb first.")
-        return None, None
 
-    if app_id in _cnmts_db:
-        app_id_keys = list(_cnmts_db[app_id].keys())
-        if len(app_id_keys):
-            app = _cnmts_db[app_id][app_id_keys[-1]]
-            
-            if app['titleType'] == 128:
-                app_type = APP_TYPE_BASE
-                title_id = app_id.upper()
-            elif app['titleType'] == 129:
-                app_type = APP_TYPE_UPD
-                if 'otherApplicationId' in app:
-                    title_id = app['otherApplicationId'].upper()
-                else:
-                    title_id = get_title_id_from_app_id(app_id, app_type)
-            elif app['titleType'] == 130:
-                app_type = APP_TYPE_DLC
-                if 'otherApplicationId' in app:
-                    title_id = app['otherApplicationId'].upper()
-                else:
-                    title_id = get_title_id_from_app_id(app_id, app_type)
-        else:
-            logger.warning(f'{app_id} has no keys in cnmts_db, fallback to default identification.')
-            if app_id.endswith('000'):
-                app_type = APP_TYPE_BASE
-                title_id = app_id
-            elif app_id.endswith('800'):
-                app_type = APP_TYPE_UPD
-                title_id = get_title_id_from_app_id(app_id, app_type)
-            else:
-                app_type = APP_TYPE_DLC
-                title_id = get_title_id_from_app_id(app_id, app_type)
-    else:
-        logger.warning(f'{app_id} not in cnmts_db, fallback to default identification.')
+    cnmt = titledb_store.get_cnmt_latest(app_id)
+    if cnmt is None:
+        logger.warning(f'{app_id} not in cnmts, fallback to default identification.')
         if app_id.endswith('000'):
-            app_type = APP_TYPE_BASE
-            title_id = app_id
-        elif app_id.endswith('800'):
-            app_type = APP_TYPE_UPD
-            title_id = get_title_id_from_app_id(app_id, app_type)
-        else:
-            app_type = APP_TYPE_DLC
-            title_id = get_title_id_from_app_id(app_id, app_type)
-    
-    return title_id.upper(), app_type
+            return app_id.upper(), APP_TYPE_BASE
+        if app_id.endswith('800'):
+            return get_title_id_from_app_id(app_id, APP_TYPE_UPD), APP_TYPE_UPD
+        return get_title_id_from_app_id(app_id, APP_TYPE_DLC), APP_TYPE_DLC
 
-def load_titledb():
-    global _cnmts_db
-    global _titles_db
-    global _versions_db
-    global _versions_txt_db
-    global identification_in_progress_count
-    global _titles_db_loaded
+    title_type = cnmt.get('titleType')
+    other_app_id = cnmt.get('otherApplicationId')
+    if title_type == 128:
+        return app_id.upper(), APP_TYPE_BASE
+    if title_type == 129:
+        if other_app_id:
+            return other_app_id.upper(), APP_TYPE_UPD
+        return get_title_id_from_app_id(app_id, APP_TYPE_UPD), APP_TYPE_UPD
+    if title_type == 130:
+        if other_app_id:
+            return other_app_id.upper(), APP_TYPE_DLC
+        return get_title_id_from_app_id(app_id, APP_TYPE_DLC), APP_TYPE_DLC
 
-    identification_in_progress_count += 1
-    if not _titles_db_loaded:
-        logger.info("Loading TitleDBs into memory...")
-        app_settings = get_settings()
-        with open(os.path.join(TITLEDB_DIR, 'cnmts.json'), "r", encoding="utf-8") as f:
-            _cnmts_db = json.load(f)
-
-        with open(os.path.join(TITLEDB_DIR, titledb.get_region_titles_file(app_settings)), "r", encoding="utf-8") as f:
-            _titles_db = json.load(f)
-
-        with open(os.path.join(TITLEDB_DIR, 'versions.json'), "r", encoding="utf-8") as f:
-            _versions_db = json.load(f)
-
-        _versions_txt_db = {}
-        with open(os.path.join(TITLEDB_DIR, 'versions.txt'), "r", encoding="utf-8") as f:
-            for line in f:
-                line_strip = line.rstrip("\n")
-                app_id, rightsId, version = line_strip.split('|')
-                if not version:
-                    version = "0"
-                _versions_txt_db[app_id] = version
-        _titles_db_loaded = True
-        logger.info("TitleDBs loaded.")
-
-@debounce(30)
-def unload_titledb():
-    global _cnmts_db
-    global _titles_db
-    global _versions_db
-    global _versions_txt_db
-    global identification_in_progress_count
-    global _titles_db_loaded
-
-    if identification_in_progress_count:
-        logger.debug('Identification still in progress, not unloading TitleDB.')
-        return
-
-    logger.info("Unloading TitleDBs from memory...")
-    _cnmts_db = None
-    _titles_db = None
-    _versions_db = None
-    _versions_txt_db = None
-    _titles_db_loaded = False
-    logger.info("TitleDBs unloaded.")
+    logger.warning(f'{app_id} has unknown titleType {title_type}, fallback to default identification.')
+    if app_id.endswith('000'):
+        return app_id.upper(), APP_TYPE_BASE
+    if app_id.endswith('800'):
+        return get_title_id_from_app_id(app_id, APP_TYPE_UPD), APP_TYPE_UPD
+    return get_title_id_from_app_id(app_id, APP_TYPE_DLC), APP_TYPE_DLC
 
 def identify_file_from_filename(filename):
     title_id = None
@@ -305,94 +231,8 @@ def identify_file(filepath):
     return identification, success, contents, error
 
 
-def get_game_info(title_id):
-    global _titles_db
-    if _titles_db is None:
-        logger.error("titles_db is not loaded. Call load_titledb first.")
-        return None
-
-    try:
-        title_info = [_titles_db[t] for t in list(_titles_db.keys()) if _titles_db[t]['id'] == title_id][0]
-        return {
-            'name': title_info['name'],
-            'bannerUrl': title_info['bannerUrl'],
-            'iconUrl': title_info['iconUrl'],
-            'id': title_info['id'],
-            'category': title_info['category'],
-        }
-    except Exception:
-        logger.error(f"Title ID not found in titledb: {title_id}")
-        return {
-            'name': 'Unrecognized',
-            'bannerUrl': '//placehold.it/400x200',
-            'iconUrl': '',
-            'id': title_id + ' not found in titledb',
-            'category': '',
-        }
-
 def get_update_number(version):
     return int(version)//65536
 
 def get_game_latest_version(all_existing_versions):
     return max(v['version'] for v in all_existing_versions)
-
-def get_all_existing_versions(titleid):
-    global _versions_db
-    if _versions_db is None:
-        logger.error("versions_db is not loaded. Call load_titledb first.")
-        return []
-
-    titleid = titleid.lower()
-    if titleid not in _versions_db:
-        # print(f'Title ID not in versions.json: {titleid.upper()}')
-        return []
-
-    versions_from_db = _versions_db[titleid].keys()
-    return [
-        {
-            'version': int(version_from_db),
-            'update_number': get_update_number(version_from_db),
-            'release_date': _versions_db[titleid][str(version_from_db)],
-        }
-        for version_from_db in versions_from_db
-    ]
-
-def get_all_app_existing_versions(app_id):
-    global _cnmts_db
-    if _cnmts_db is None:
-        logger.error("cnmts_db is not loaded. Call load_titledb first.")
-        return None
-
-    app_id = app_id.lower()
-    if app_id in _cnmts_db:
-        versions_from_cnmts_db = _cnmts_db[app_id].keys()
-        if len(versions_from_cnmts_db):
-            return sorted(versions_from_cnmts_db)
-        else:
-            logger.warning(f'No keys in cnmts.json for app ID: {app_id.upper()}')
-            return None
-    else:
-        # print(f'DLC app ID not in cnmts.json: {app_id.upper()}')
-        return None
-    
-def get_app_id_version_from_versions_txt(app_id):
-    global _versions_txt_db
-    if _versions_txt_db is None:
-        logger.error("versions_txt_db is not loaded. Call load_titledb first.")
-        return None
-    return _versions_txt_db.get(app_id, None)
-    
-def get_all_existing_dlc(title_id):
-    global _cnmts_db
-    if _cnmts_db is None:
-        logger.error("cnmts_db is not loaded. Call load_titledb first.")
-        return []
-
-    title_id = title_id.lower()
-    dlcs = []
-    for app_id in _cnmts_db.keys():
-        for version, version_description in _cnmts_db[app_id].items():
-            if version_description.get('titleType') == 130 and version_description.get('otherApplicationId') == title_id:
-                if app_id.upper() not in dlcs:
-                    dlcs.append(app_id.upper())
-    return dlcs


### PR DESCRIPTION
Import TitleDB content in a sql database, now workers can identify content without having to load the json in memory.
The SQL format allows to add custom entries to the database, compatible with the identification flow.
- replace json loading by direct db access
- initial support for custom entries