### PR TITLE
Fix organizer filenames

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -130,6 +130,18 @@ RESTRICTED_CHARS_UNIX = {'/': '／'}
 # A Windows name cannot end with a period, only replaced as the last character
 TRAILING_DOT_WINDOWS = '．'
 
+# Windows path length limits, one char shorter than the documented values
+# to account for the terminating NUL
+MAX_PATH_WINDOWS = 259
+MAX_DIR_PATH_WINDOWS = 247 # Directories need room for a 8.3 filename
+MAX_PART_WINDOWS = 255
+MIN_PART_WINDOWS = 8 # Never truncate a name below this
+TRUNCATION_MARKER = '…' # Marks a name that had to be shortened
+TEMPLATE_NAME_KEYS = ('titleName', 'appName') # Organizer template values shortened to fit a path
+# Leaves room for a library path of ~60 characters and shortens only 0.4% of known titles.
+MAX_NAME_WINDOWS = 80
+COLLISION_SUFFIX_RESERVE = 4 # Room for the "(n)" suffix added on filename collisions
+
 # Reserved names on Windows
 RESERVED_NAMES_WINDOWS = {
     'con', 'prn', 'aux', 'nul', 'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',

--- a/app/constants.py
+++ b/app/constants.py
@@ -121,9 +121,14 @@ APP_TYPE_FILTERS = {
     'multi': 'MULTI'
 }
 
-# Define OS-specific forbidden characters for Organizer
-FORBIDDEN_CHARS_WINDOWS = set('<>:"/\\|?*')
-FORBIDDEN_CHARS_UNIX = set('/') # Only / is truly forbidden on Unix-like systems
+# OS-specific restricted characters, mapped to their full-width equivalents
+RESTRICTED_CHARS_WINDOWS = {
+    '/': '／', '\\': '＼', ':': '：', '*': '＊', '?': '？',
+    '"': '＂', '<': '＜', '>': '＞', '|': '｜'
+}
+RESTRICTED_CHARS_UNIX = {'/': '／'}
+# A Windows name cannot end with a period, only replaced as the last character
+TRAILING_DOT_WINDOWS = '．'
 
 # Reserved names on Windows
 RESERVED_NAMES_WINDOWS = {

--- a/app/library.py
+++ b/app/library.py
@@ -13,21 +13,9 @@ from pathlib import Path
 from utils import *
 from db import update_file_path
 
-def sanitize_filename(name, windows_compatible=False):
-    """Replace restricted characters with their full-width equivalents."""
-    windows = sys.platform == 'win32' or windows_compatible
-    restricted_chars = RESTRICTED_CHARS_WINDOWS if windows else RESTRICTED_CHARS_UNIX
-    sanitized = ''.join(replace_char(c, restricted_chars, windows) for c in name).strip()
-
-    if windows:
-        # A Windows name cannot end with a period
-        if sanitized.endswith('.'):
-            sanitized = sanitized[:-1] + TRAILING_DOT_WINDOWS
-        # Handle Windows reserved names
-        if sanitized.lower() in RESERVED_NAMES_WINDOWS:
-            sanitized = '_' + sanitized # Prepend an underscore to avoid conflict
-
-    return sanitized
+def fit_template_names(format_data):
+    """Cap the names used in a template to a fixed length, leaving the rest of the template intact."""
+    return {k: trim_name(v, MAX_NAME_WINDOWS) if k in TEMPLATE_NAME_KEYS else v for k, v in format_data.items()}
 
 def organize_file(file_obj, library_path, organizer_settings):
     try:
@@ -64,10 +52,13 @@ def organize_file(file_obj, library_path, organizer_settings):
             else:
                 format_data["appName"] = title_info['name']
         
-        # Format the new relative path and remove leading slash if present
-        raw_path = template.format(**format_data).lstrip('/')
+        # Format the new relative path, shortening the names first if they cannot fit
         windows_compatible = organizer_settings.get('windows_compatible', False)
-        safe_parts = [sanitize_filename(part, windows_compatible) for part in Path(raw_path).parts]
+        if sys.platform == 'win32' or windows_compatible:
+            format_data = fit_template_names(format_data)
+        safe_parts = sanitized_path_parts(template.format(**format_data), windows_compatible)
+        if sys.platform == 'win32' or windows_compatible:
+            safe_parts = truncate_path_parts(safe_parts, len(library_path))
         new_relative_path = os.path.join(*safe_parts)
         
         # Construct the full new path

--- a/app/library.py
+++ b/app/library.py
@@ -14,21 +14,18 @@ from utils import *
 from db import update_file_path
 
 def sanitize_filename(name, windows_compatible=False):
-    if sys.platform == 'win32' or windows_compatible:
-        forbidden_chars = FORBIDDEN_CHARS_WINDOWS
-        # Replace forbidden characters with underscore
-        sanitized = ''.join('' if c in forbidden_chars else c for c in name)
-        # Remove trailing periods and spaces specific to Windows
-        sanitized = sanitized.strip().rstrip('. ')
+    """Replace restricted characters with their full-width equivalents."""
+    windows = sys.platform == 'win32' or windows_compatible
+    restricted_chars = RESTRICTED_CHARS_WINDOWS if windows else RESTRICTED_CHARS_UNIX
+    sanitized = ''.join(replace_char(c, restricted_chars, windows) for c in name).strip()
+
+    if windows:
+        # A Windows name cannot end with a period
+        if sanitized.endswith('.'):
+            sanitized = sanitized[:-1] + TRAILING_DOT_WINDOWS
         # Handle Windows reserved names
         if sanitized.lower() in RESERVED_NAMES_WINDOWS:
             sanitized = '_' + sanitized # Prepend an underscore to avoid conflict
-    else:
-        forbidden_chars = FORBIDDEN_CHARS_UNIX
-        # Replace forbidden characters with underscore
-        sanitized = ''.join('_' if c in forbidden_chars else c for c in name)
-        # Remove leading/trailing spaces (general good practice)
-        sanitized = sanitized.strip()
 
     return sanitized
 

--- a/app/library.py
+++ b/app/library.py
@@ -13,9 +13,13 @@ from pathlib import Path
 from utils import *
 from db import update_file_path
 
-def fit_template_names(format_data):
-    """Cap the names used in a template to a fixed length, leaving the rest of the template intact."""
-    return {k: trim_name(v, MAX_NAME_WINDOWS) if k in TEMPLATE_NAME_KEYS else v for k, v in format_data.items()}
+def prepare_template_names(format_data, windows_compatible):
+    """Sanitize the names before formatting, so they cannot introduce path separators, and cap their length."""
+    names = {k: sanitize_filename(v, windows_compatible) for k, v in format_data.items() if k in TEMPLATE_NAME_KEYS}
+    if sys.platform == 'win32' or windows_compatible:
+        names = {k: trim_name(v, MAX_NAME_WINDOWS) for k, v in names.items()}
+
+    return {**format_data, **names}
 
 def organize_file(file_obj, library_path, organizer_settings):
     try:
@@ -52,10 +56,9 @@ def organize_file(file_obj, library_path, organizer_settings):
             else:
                 format_data["appName"] = title_info['name']
         
-        # Format the new relative path, shortening the names first if they cannot fit
+        # Format the new relative path, sanitizing and shortening the names first
         windows_compatible = organizer_settings.get('windows_compatible', False)
-        if sys.platform == 'win32' or windows_compatible:
-            format_data = fit_template_names(format_data)
+        format_data = prepare_template_names(format_data, windows_compatible)
         safe_parts = sanitized_path_parts(template.format(**format_data), windows_compatible)
         if sys.platform == 'win32' or windows_compatible:
             safe_parts = truncate_path_parts(safe_parts, len(library_path))

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -305,7 +305,7 @@
                             <input type="checkbox" class="form-check-input" id="windowsCompatibleCheck">
                             <label class="form-check-label" for="windowsCompatibleCheck">Windows compatible filenames</label>
                             <div class="form-text">Ownfoil enforces filename sanitization depending on the OS running it. Enabling this will sanitize filenames with
-                                Windows compatible characters, this is needed when acessing libraries from Windows systems (e.g. SMB/NFS mount).</div>
+                                Windows compatible characters and keep paths within the Windows length limit, this is needed when acessing libraries from Windows systems (e.g. SMB/NFS mount).</div>
                         </div>
                     </div>
                 </div>

--- a/app/utils.py
+++ b/app/utils.py
@@ -271,6 +271,16 @@ def delete_empty_folders(path):
             break # No more empty directories found in this pass, so we are done
 
 
+def replace_char(c, restricted_chars, control_chars):
+    """Map a character to its filesystem-safe replacement, if any."""
+    if c in restricted_chars:
+        return restricted_chars[c]
+    # Control characters map to their Unicode "control pictures" equivalent
+    if ord(c) < 0x20 and (control_chars or c == '\0'):
+        return chr(0x2400 + ord(c))
+    return c
+
+
 def human_size(n):
     """Format a byte count as a human-readable size (e.g. '2.7 GB')."""
     size = float(n)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,13 +1,16 @@
 import logging
 import re
+import sys
 import threading
 import time
 from datetime import timedelta
 from functools import wraps
+from pathlib import Path
 from typing import Optional, Tuple
 import json
 import os
 import tempfile
+from constants import *
 
 # Global lock for all JSON writes in this process
 _json_write_lock = threading.Lock()
@@ -279,6 +282,65 @@ def replace_char(c, restricted_chars, control_chars):
     if ord(c) < 0x20 and (control_chars or c == '\0'):
         return chr(0x2400 + ord(c))
     return c
+
+
+def sanitize_filename(name, windows_compatible=False):
+    """Replace restricted characters with their full-width equivalents."""
+    windows = sys.platform == 'win32' or windows_compatible
+    restricted_chars = RESTRICTED_CHARS_WINDOWS if windows else RESTRICTED_CHARS_UNIX
+    sanitized = ''.join(replace_char(c, restricted_chars, windows) for c in name).strip()
+
+    if windows:
+        # A Windows name cannot end with a period
+        if sanitized.endswith('.'):
+            sanitized = sanitized[:-1] + TRAILING_DOT_WINDOWS
+        # Handle Windows reserved names
+        if sanitized.lower() in RESERVED_NAMES_WINDOWS:
+            sanitized = '_' + sanitized # Prepend an underscore to avoid conflict
+
+    return sanitized
+
+
+def sanitized_path_parts(raw_path, windows_compatible):
+    """Split a formatted path into filesystem-safe path parts."""
+    return [sanitize_filename(part, windows_compatible) for part in Path(raw_path.lstrip('/')).parts]
+
+
+def trim_name(name, length):
+    """Cut a name to length, marking the truncation with an ellipsis."""
+    length = max(length, 1)
+    if len(name) <= length:
+        return name
+    return name[:length - 1].rstrip('. ') + TRUNCATION_MARKER
+
+
+def truncate_path_parts(parts, prefix_len):
+    """Shorten path parts, directories first, so that prefix + path fits within MAX_PATH."""
+    *dirs, filename = parts
+    dirs = [trim_name(d, MAX_PART_WINDOWS) for d in dirs]
+    stem, _, ext = filename.rpartition('.')
+    if not stem:
+        stem, ext = filename, ''
+    ext_len = len(ext) + 1 if ext else 0
+    # Length taken by the directories, each preceded by a separator
+    dirs_len = lambda: sum(len(d) + 1 for d in dirs)
+    # Budget left for the stem, keeping room for its extension and a collision suffix
+    stem_room = lambda: min(MAX_PART_WINDOWS - ext_len,
+                            MAX_PATH_WINDOWS - prefix_len - dirs_len() - 1 - ext_len - COLLISION_SUFFIX_RESERVE)
+
+    # Shrink the longest directory until the filename has room and mkdir's own limit is met
+    while dirs and max(len(d) for d in dirs) > MIN_PART_WINDOWS:
+        if prefix_len + dirs_len() <= MAX_DIR_PATH_WINDOWS and stem_room() >= MIN_PART_WINDOWS:
+            break
+        longest = max(range(len(dirs)), key=lambda i: len(dirs[i]))
+        dirs[longest] = trim_name(dirs[longest], len(dirs[longest]) - 1)
+
+    stem = trim_name(stem, stem_room())
+    filename = f'{stem}.{ext}' if ext else stem
+    if prefix_len + dirs_len() + 1 + len(filename) > MAX_PATH_WINDOWS:
+        logging.getLogger('main').warning(f"Path too long for Windows even after truncation: {os.path.join(*dirs, filename)}")
+
+    return dirs + [filename]
 
 
 def human_size(n):

--- a/tests/test_organizer_paths.py
+++ b/tests/test_organizer_paths.py
@@ -1,0 +1,149 @@
+"""Filename sanitization and Windows path length enforcement for the organizer."""
+import os
+import pytest
+
+from constants import (
+    COLLISION_SUFFIX_RESERVE,
+    MAX_DIR_PATH_WINDOWS,
+    MAX_PART_WINDOWS,
+    MAX_PATH_WINDOWS,
+    MAX_NAME_WINDOWS,
+    MIN_PART_WINDOWS,
+    TEMPLATE_NAME_KEYS,
+    TRUNCATION_MARKER,
+)
+from library import fit_template_names
+from utils import sanitize_filename, sanitized_path_parts, truncate_path_parts
+
+SANITIZE_CASES = [
+    # name, windows, expected
+    ('Pokémon: Let\'s Go', True, 'Pokémon： Let\'s Go'),
+    ('Pokémon: Let\'s Go', False, 'Pokémon: Let\'s Go'),
+    ('A/B', True, 'A／B'),
+    ('A/B', False, 'A／B'),
+    ('<t> "x"|y?*\\z', True, '＜t＞ ＂x＂｜y？＊＼z'),
+    ('<t> "x"|y?*\\z', False, '<t> "x"|y?*\\z'),
+    ('  spaced  ', True, 'spaced'),
+    ('  spaced  ', False, 'spaced'),
+    ('Game. ', True, 'Game．'),
+    ('Game. ', False, 'Game.'),
+    ('Mr. Driller', True, 'Mr. Driller'),
+    ('CON', True, '_CON'),
+    ('con', False, 'con'),
+    ('bell\x07', True, 'bell␇'),
+    ('nul\x00', False, 'nul␀'),
+]
+
+
+@pytest.mark.parametrize('name, windows, expected', SANITIZE_CASES)
+def test_sanitize_filename(name, windows, expected):
+    assert sanitize_filename(name, windows_compatible=windows) == expected
+
+
+def _full_len(parts, prefix_len):
+    return prefix_len + sum(len(p) + 1 for p in parts)
+
+
+MON_YU = ('MON-YU： DEFEAT MONSTERS AND GAIN STRONG WEAPONS AND ARMOR. YOU MAY BE DEFEATED, BUT DON’T '
+          'GIVE UP. BECOME STRONGER. I BELIEVE THERE WILL BE A DAY WHEN THE HEROES DEFEAT THE DEVIL KING')
+
+TRUNCATE_CASES = [
+    # id, prefix_len, parts
+    ('short path untouched', 10, ['Title', 'Title [0100].nsp']),
+    ('long real title', 6, [MON_YU, f'{MON_YU} [0100E7500BF84000][v0].nsp']),
+    ('long real title, long prefix', 43, [MON_YU, f'{MON_YU} [0100E7500BF84000][v0].nsp']),
+    ('long filename', 10, ['Title', 'T' * 400 + '.nsp']),
+    ('long directory', 10, ['D' * 400, 'Title [0100].nsp']),
+    ('several long directories', 10, ['D' * 200, 'E' * 200, 'F' * 200, 'Title.nsp']),
+    ('long prefix', 200, ['Some Long Title Name', 'Some Long Title Name [0100].nsp']),
+    ('no directory', 10, ['T' * 400 + '.nsp']),
+    ('no extension', 10, ['Title', 'T' * 400]),
+]
+
+
+@pytest.mark.parametrize('case_id, prefix_len, parts', TRUNCATE_CASES, ids=[c[0] for c in TRUNCATE_CASES])
+def test_truncate_path_parts(case_id, prefix_len, parts):
+    result = truncate_path_parts(list(parts), prefix_len)
+
+    assert len(result) == len(parts)
+    # A collision suffix must still fit within the limit
+    assert _full_len(result, prefix_len) + COLLISION_SUFFIX_RESERVE <= MAX_PATH_WINDOWS
+    assert prefix_len + sum(len(p) + 1 for p in result[:-1]) <= MAX_DIR_PATH_WINDOWS
+    assert all(len(p) <= MAX_PART_WINDOWS for p in result)
+    # Nothing is shortened more than necessary, and each part stays usable
+    assert all(len(new) <= len(old) for new, old in zip(result, parts))
+    assert all(len(p) >= min(MIN_PART_WINDOWS, len(old)) for p, old in zip(result, parts))
+    # Truncation never leaves a name Windows would reject
+    assert all(p == p.rstrip() and not p.endswith('.') for p in result)
+    # The extension is preserved
+    assert os.path.splitext(result[-1])[1] == os.path.splitext(parts[-1])[1]
+    # Shortened names, and only those, are marked with the ellipsis
+    for new, old in zip(result, parts):
+        assert (TRUNCATION_MARKER in new) == (len(new) < len(old))
+
+
+BASE_TEMPLATE = '{titleName}/{titleName} [{appId}][v{appVersion}].{extension}'
+DLC_TEMPLATE = '{titleName}/{appName} [{appId}][v{appVersion}].{extension}'
+
+FIT_CASES = [
+    # id, template, prefix_len, title_name, app_name
+    ('short name untouched', BASE_TEMPLATE, 6, 'Celeste', 'Celeste'),
+    ('long name, short prefix', BASE_TEMPLATE, 6, MON_YU, MON_YU),
+    ('long name, long prefix', BASE_TEMPLATE, 43, MON_YU, MON_YU),
+    ('long dlc names', DLC_TEMPLATE, 43, MON_YU, MON_YU + ' - SEASON PASS BUNDLE'),
+    ('long title, short dlc', DLC_TEMPLATE, 43, MON_YU, 'Extra Costumes'),
+]
+
+
+def _organized_parts(template, data, prefix_len):
+    parts = sanitized_path_parts(template.format(**fit_template_names(data)), True)
+    return truncate_path_parts(parts, prefix_len)
+
+
+@pytest.mark.parametrize('case_id, template, prefix_len, title_name, app_name',
+                         FIT_CASES, ids=[c[0] for c in FIT_CASES])
+def test_fit_template_names(case_id, template, prefix_len, title_name, app_name):
+    data = {'titleName': title_name, 'appName': app_name, 'appId': '0100E7500BF84000',
+            'appVersion': '65536', 'extension': 'nsp'}
+    fitted = fit_template_names(dict(data))
+    parts = _organized_parts(template, dict(data), prefix_len)
+
+    assert _full_len(parts, prefix_len) + COLLISION_SUFFIX_RESERVE <= MAX_PATH_WINDOWS
+    # Only the names are shortened, the rest of the template survives
+    assert parts[-1].endswith(f'[{data["appId"]}][v{data["appVersion"]}].nsp')
+    assert all(fitted[k] == v for k, v in data.items() if k not in TEMPLATE_NAME_KEYS)
+    # A name is only shortened when it exceeds the cap, and always to the same value
+    for key in TEMPLATE_NAME_KEYS:
+        assert len(fitted[key]) <= MAX_NAME_WINDOWS
+        assert (TRUNCATION_MARKER in fitted[key]) == (len(data[key]) > MAX_NAME_WINDOWS)
+    assert parts[0] == sanitize_filename(fitted['titleName'], True)
+
+
+@pytest.mark.parametrize('prefix_len', [6, 43, 62])
+def test_title_directory_is_independent_of_the_file(prefix_len):
+    """Files of the same title must land in the same folder, whatever their own name."""
+    base = {'titleName': MON_YU, 'appId': '0100E7500BF84000', 'appVersion': '0', 'extension': 'nsp'}
+    dirs = {
+        _organized_parts(DLC_TEMPLATE, {**base, 'appName': app_name}, prefix_len)[0]
+        for app_name in ('Extra Costumes', MON_YU, MON_YU + ' - SEASON PASS BUNDLE', 'A' * 300)
+    }
+    assert len(dirs) == 1
+
+
+def test_fit_template_names_is_independent_of_the_library_path():
+    data = {'titleName': MON_YU, 'appName': MON_YU, 'appId': '0100E7500BF84000',
+            'appVersion': '0', 'extension': 'nsp'}
+    assert _organized_parts(BASE_TEMPLATE, dict(data), 6) == _organized_parts(BASE_TEMPLATE, dict(data), 62)
+
+
+def test_truncate_keeps_directories_when_filename_can_absorb():
+    parts = ['Directory', 'F' * 400 + '.nsp']
+    result = truncate_path_parts(list(parts), 10)
+    assert result[0] == 'Directory'
+
+
+def test_truncate_shrinks_directories_before_starving_the_filename():
+    parts = ['D' * 300, 'F' * 300 + '.nsp']
+    result = truncate_path_parts(list(parts), 10)
+    assert len(result[0]) < MAX_PART_WINDOWS
+    assert len(os.path.splitext(result[-1])[0]) >= MIN_PART_WINDOWS

--- a/tests/test_organizer_paths.py
+++ b/tests/test_organizer_paths.py
@@ -12,7 +12,7 @@ from constants import (
     TEMPLATE_NAME_KEYS,
     TRUNCATION_MARKER,
 )
-from library import fit_template_names
+from library import prepare_template_names
 from utils import sanitize_filename, sanitized_path_parts, truncate_path_parts
 
 SANITIZE_CASES = [
@@ -32,6 +32,8 @@ SANITIZE_CASES = [
     ('con', False, 'con'),
     ('bell\x07', True, 'bell␇'),
     ('nul\x00', False, 'nul␀'),
+    ('void* tRrLM2(); //Void Terrarium 2', True, 'void＊ tRrLM2(); ／／Void Terrarium 2'),
+    ('void* tRrLM2(); //Void Terrarium 2', False, 'void* tRrLM2(); ／／Void Terrarium 2'),
 ]
 
 
@@ -96,7 +98,7 @@ FIT_CASES = [
 
 
 def _organized_parts(template, data, prefix_len):
-    parts = sanitized_path_parts(template.format(**fit_template_names(data)), True)
+    parts = sanitized_path_parts(template.format(**prepare_template_names(data, True)), True)
     return truncate_path_parts(parts, prefix_len)
 
 
@@ -105,7 +107,7 @@ def _organized_parts(template, data, prefix_len):
 def test_fit_template_names(case_id, template, prefix_len, title_name, app_name):
     data = {'titleName': title_name, 'appName': app_name, 'appId': '0100E7500BF84000',
             'appVersion': '65536', 'extension': 'nsp'}
-    fitted = fit_template_names(dict(data))
+    fitted = prepare_template_names(dict(data), True)
     parts = _organized_parts(template, dict(data), prefix_len)
 
     assert _full_len(parts, prefix_len) + COLLISION_SUFFIX_RESERVE <= MAX_PATH_WINDOWS
@@ -128,6 +130,32 @@ def test_title_directory_is_independent_of_the_file(prefix_len):
         for app_name in ('Extra Costumes', MON_YU, MON_YU + ' - SEASON PASS BUNDLE', 'A' * 300)
     }
     assert len(dirs) == 1
+
+
+SEPARATOR_CASES = [
+    # title_name, app_name, expected title directory
+    ('void* tRrLM2(); //Void Terrarium 2', 'DLC/Extra', 'void＊ tRrLM2(); ／／Void Terrarium 2'),
+    ('Fate/EXTELLA LINK', 'Fate/EXTELLA Costume', 'Fate／EXTELLA LINK'),
+]
+
+
+@pytest.mark.parametrize('windows', [True, False])
+@pytest.mark.parametrize('title_name, app_name, windows_dir', SEPARATOR_CASES)
+def test_names_cannot_introduce_path_separators(windows, title_name, app_name, windows_dir):
+    """A name containing a slash must stay one path part, not create directories."""
+    data = {'titleName': title_name, 'appName': app_name,
+            'appId': '0100', 'appVersion': '0', 'extension': 'nsp'}
+    prepared = prepare_template_names(dict(data), windows)
+    parts = sanitized_path_parts(DLC_TEMPLATE.format(**prepared), windows)
+
+    assert len(parts) == 2
+    assert parts[0] == prepared['titleName']
+    assert parts[-1] == f'{prepared["appName"]} [0100][v0].nsp'
+    # The slashes are replaced, on every platform
+    assert not any('/' in p for p in parts)
+    assert all(p.count('／') == old.count('/') for p, old in zip(parts, (title_name, app_name)))
+    if windows:
+        assert parts[0] == windows_dir
 
 
 def test_fit_template_names_is_independent_of_the_library_path():


### PR DESCRIPTION
- #310 :
truncate `titleName` value in template to 80 characters (impacts 0.4% of 46,285 titles), in both directory and file names. If final path with library prefix exceeds the limit, then it is further truncated to fit.
- #329 :
replace forbbiden Linux/Windows character with full-width equivalent, as done by [rclone](https://rclone.org/local/#restricted-characters).