### PR TITLE
fix(verification): fix issue https://github.com/a1ex4/ownfoil/issues/357

### DIFF
--- a/app/containers/verification.py
+++ b/app/containers/verification.py
@@ -151,6 +151,11 @@ def verify(filepath, depth, progress=None):
                 hash_modified = _modified_from(messages)
     except Exception as e:
         logger.warning(f'Verification of {os.path.basename(filepath)} failed: {e}')
-        return False, (False if depth == DEPTH_HASH else None), None, str(e)
+        # A raised phase is a verdict, not an absent result. At hash depth both hash columns
+        # have to be written: a null hash_modified next to a failed hash is how the verify
+        # stage recognises a row from before that column existed and schedules a re-check,
+        # so leaving it null here would re-verify an unreadable file on every sweep.
+        failed = False if depth == DEPTH_HASH else None
+        return False, failed, failed, str(e)
 
     return signature_valid, hash_valid, hash_modified, _error_from(messages)

--- a/app/file_watcher.py
+++ b/app/file_watcher.py
@@ -213,7 +213,7 @@ class Handler(FileSystemEventHandler):
         tracked = 0
         for root, _, files in os.walk(dirpath):
             for name in files:
-                if not any(name.endswith(ext) for ext in ALLOWED_EXTENSIONS):
+                if not is_library_file(name):
                     continue
                 path = os.path.join(root, name)
                 if os.path.exists(path):
@@ -278,8 +278,7 @@ class Handler(FileSystemEventHandler):
         if source_event.event_type not in ('created', 'modified', 'moved', 'deleted'):
             return
 
-        is_media = any(source_event.src_path.endswith(ext) or source_event.dest_path.endswith(ext)
-                       for ext in ALLOWED_EXTENSIONS)
+        is_media = is_library_file(source_event.src_path) or is_library_file(source_event.dest_path)
 
         # ReadDirectoryChangesW reports a removed entry as FILE_ACTION_REMOVED with no type, and
         # watchdog turns that into a FileDeletedEvent even for a folder (the entry is gone, so
@@ -303,7 +302,7 @@ class Handler(FileSystemEventHandler):
             dest_path=source_event.dest_path,
         )
 
-        if library_event.type == 'moved' and not any(library_event.dest_path.endswith(ext) for ext in ALLOWED_EXTENSIONS):
+        if library_event.type == 'moved' and not is_library_file(library_event.dest_path):
             library_event.type = 'deleted'
 
         if library_event.type == 'deleted':

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -634,7 +634,7 @@ def scan_library_task(library_path, **kwargs):
         return
 
     logger.info(f'Scanning library path {library_path} ...')
-    _, files = titles_lib.getDirsAndFiles(library_path)
+    _, files = titles_lib.get_dirs_and_files(library_path)
     skip = set(get_library_file_paths(library_id)) | get_temp_file_paths()
     new_files = [f for f in files if f not in skip]
 

--- a/app/titles.py
+++ b/app/titles.py
@@ -25,21 +25,21 @@ get_all_app_existing_versions = titledb.store.get_all_app_existing_versions
 get_all_existing_dlc = titledb.store.get_all_existing_dlc
 get_all_dlc_versions = titledb.store.get_all_dlc_versions
 
-def getDirsAndFiles(path):
+def get_dirs_and_files(path):
     entries = os.listdir(path)
-    allFiles = []
-    allDirs = []
+    all_files = []
+    all_dirs = []
 
     for entry in entries:
-        fullPath = os.path.join(path, entry)
-        if os.path.isdir(fullPath):
-            allDirs.append(fullPath)
-            dirs, files = getDirsAndFiles(fullPath)
-            allDirs += dirs
-            allFiles += files
-        elif fullPath.split('.')[-1] in ALLOWED_EXTENSIONS:
-            allFiles.append(fullPath)
-    return allDirs, allFiles
+        full_path = os.path.join(path, entry)
+        if os.path.isdir(full_path):
+            all_dirs.append(full_path)
+            dirs, files = get_dirs_and_files(full_path)
+            all_dirs += dirs
+            all_files += files
+        elif is_library_file(entry):
+            all_files.append(full_path)
+    return all_dirs, all_files
 
 def get_app_id_from_filename(filename):
     app_id_match = re.search(app_id_regex, filename)

--- a/app/utils.py
+++ b/app/utils.py
@@ -9,9 +9,20 @@ from datetime import timedelta
 from functools import wraps
 from pathlib import Path
 from typing import Optional, Tuple
-import json
 import os
 from constants import *
+
+def is_library_file(name):
+    """Whether a file name is one the library should index.
+
+    Matches on extension, and rejects dotfiles: macOS leaves an AppleDouble `._Game.nsp`
+    next to every file it copies onto a network share, which carries the extension but
+    holds Finder metadata rather than a container.
+    """
+    name = os.path.basename(name)
+    if name.startswith('.'):
+        return False
+    return any(name.endswith(f'.{ext}') for ext in ALLOWED_EXTENSIONS)
 
 # Shared log format used by the app, workers and the Gunicorn logger
 LOG_FORMAT = '[%(asctime)s.%(msecs)03d] %(levelname)s (%(module)s) %(message)s'
@@ -35,9 +46,9 @@ class ColoredFormatter(logging.Formatter):
         levelname = record.levelname
         if levelname in self.COLORS:
             record.levelname = f"{self.COLORS[levelname]}{levelname}{self.RESET}"
-        
+
         return super().format(record)
-    
+
 # Filter to remove date from http access logs
 class FilterRemoveDateFromWerkzeugLogs(logging.Filter):
     # '192.168.0.102 - - [30/Jun/2024 01:14:03] "%s" %s %s' -> '192.168.0.102 - "%s" %s %s'
@@ -57,7 +68,7 @@ def debounce(wait, key=None):
     """Thread-safe decorator that postpones a function's execution until after `wait` seconds
     have elapsed since the last time it was invoked. Only allows one execution at a time.
     Uses a global registry to ensure state is shared across all imports and decorator instances.
-    
+
     Args:
         wait: Number of seconds to wait before executing
         key: Optional string key to identify this function across different imports.
@@ -66,7 +77,7 @@ def debounce(wait, key=None):
     def decorator(fn):
         # Use provided key or fall back to qualname
         func_key = key if key is not None else fn.__qualname__
-        
+
         # Initialize state in global registry if not already present
         with _debounce_registry_lock:
             if func_key not in _debounce_registry:
@@ -75,26 +86,26 @@ def debounce(wait, key=None):
                     'lock': threading.Lock(),
                     'execution_lock': threading.Lock()
                 }
-        
+
         @wraps(fn)
         def debounced(*args, **kwargs):
             state = _debounce_registry[func_key]
-            
+
             def call_it():
                 # Acquire execution lock to ensure only one instance runs at a time
                 with state['execution_lock']:
                     fn(*args, **kwargs)
-            
+
             # Acquire lock to safely cancel old timer and start new one
             with state['lock']:
                 # Cancel existing timer if any
                 if state['timer'] is not None:
                     state['timer'].cancel()
-                
+
                 # Create and start new timer
                 state['timer'] = threading.Timer(wait, call_it)
                 state['timer'].start()
-        
+
         return debounced
     return decorator
 
@@ -304,7 +315,7 @@ def delete_empty_folders(path):
                     deleted_any_in_pass = True
                 except OSError as e:
                     logging.getLogger('main').error(f"Error deleting directory {dirpath}: {e}")
-        
+
         # After a full pass, check if the root path itself is now empty and can be deleted
         # This handles cases where the initial 'path' becomes empty after its children are removed
         if not os.listdir(path) and os.path.isdir(path):

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -615,7 +615,7 @@ def test_scan_and_watcher_skip_in_progress(env):
 
     from db import get_temp_file_paths, is_temp_file
     # Scanner: in-progress path is excluded from the scan's new-file set.
-    _, files = __import__("titles").getDirsAndFiles(str(env.lib_dir))
+    _, files = __import__("titles").get_dirs_and_files(str(env.lib_dir))
     skip = get_temp_file_paths()
     assert target in files and target not in [f for f in files if f not in skip]
     # Watcher gate.

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -156,6 +156,12 @@ def _non_allowed_extension(c):
     (c.watched / "readme.txt").write_text("data")
 
 
+def _apple_double_twin(c):
+    # macOS writes `._Game.nsp` beside every file it copies onto a network share: right
+    # extension, Finder metadata inside. It must never reach the library (issue #357).
+    (c.watched / "._a.nsp").write_text("\x00\x05\x16\x07 AppleDouble")
+
+
 def _dir_moved_in_atomic(c):
     game = c.outside / "Game"
     game.mkdir()
@@ -200,6 +206,8 @@ CASES = [
     ("file_moved_in",              _file_moved_in,            [("created", "a.nsp")],        []),
     ("non_allowed_extension",      _non_allowed_extension,    [],
         [("created", "readme.txt"), ("modified", "readme.txt")]),
+    ("apple_double_twin",          _apple_double_twin,        [],
+        [("created", "._a.nsp"), ("modified", "._a.nsp")]),
     ("dir_moved_in_atomic",        _dir_moved_in_atomic,      [("created", "g.nsp")],        []),
     ("dir_created_then_populated", _dir_created_then_populated, [("created", "g.nsp")],      []),
     ("dir_moved_out",              _dir_moved_out,            [("dir_deleted", "Game")],     []),

--- a/tests/test_library_files.py
+++ b/tests/test_library_files.py
@@ -1,0 +1,37 @@
+"""Which names on disk count as library files - the scanner and the watcher share one answer."""
+import pytest
+
+import titles
+from utils import is_library_file
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("Game.nsp", True),
+    ("Game.NSP", False),            # extensions are matched as written, as before
+    ("Game [0100000000010000][v0].xcz", True),
+    ("readme.txt", False),
+    ("Game.nsp.part", False),
+    # macOS AppleDouble twins carry the extension but hold Finder metadata (issue #357).
+    ("._Game.nsp", False),
+    ("._Game.xci", False),
+    (".Game.nsp", False),
+    ("/library/Title/._Game.nsp", False),
+    ("/library/Title/Game.nsp", True),
+])
+def test_is_library_file(name, expected):
+    assert is_library_file(name) is expected
+
+
+def test_scan_skips_dotfiles_but_walks_dotted_folders(tmp_path):
+    (tmp_path / "Game.nsp").write_bytes(b"x")
+    (tmp_path / "._Game.nsp").write_bytes(b"\x00\x05\x16\x07")
+    (tmp_path / ".DS_Store").write_bytes(b"x")
+    sub = tmp_path / "Title [0100000000010000]"
+    sub.mkdir()
+    (sub / "Update.nsz").write_bytes(b"x")
+    (sub / "._Update.nsz").write_bytes(b"\x00\x05\x16\x07")
+
+    dirs, files = titles.get_dirs_and_files(str(tmp_path))
+
+    assert dirs == [str(sub)]
+    assert sorted(files) == [str(tmp_path / "Game.nsp"), str(sub / "Update.nsz")]

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -143,12 +143,23 @@ def test_a_resigned_header_alone_is_not_a_modified_verdict(monkeypatch, tmp_path
 
 def test_unreadable_file_is_not_vouched_for(monkeypatch, tmp_path):
     """A phase that raises is a failure, not an absent result: we cannot vouch for a file
-    we could not read, and leaving the verdict null would retry it on every sweep."""
+    we could not read, and leaving any verdict column null would retry it on every sweep.
+    hash_modified included - a failed hash with a null hash_modified is the pre-migration
+    shape the verify stage re-checks (issue #357)."""
     _stub_phases(monkeypatch)
     monkeypatch.setattr(verification.Verify, "verify_sig",
                         lambda c, m: (_ for _ in ()).throw(OSError("master_key_0a missing")))
     assert verification.verify(str(tmp_path / "Game.nsp"), verification.DEPTH_HASH) == (
-        False, False, None, "master_key_0a missing")
+        False, False, False, "master_key_0a missing")
+
+
+def test_unopenable_file_at_hash_depth_gets_a_full_verdict(monkeypatch, tmp_path):
+    """The shape of issue #357: a file nstools cannot even open (a macOS `._` AppleDouble,
+    an XCI layout it does not support). Every column must land so the stage converges."""
+    monkeypatch.setattr(verification, "open_container",
+                        _fake_container(raises=ValueError("Not a valid PFS0 partition")))
+    assert verification.verify(str(tmp_path / "._Game.nsp"), verification.DEPTH_HASH) == (
+        False, False, False, "Not a valid PFS0 partition")
 
 
 def test_unopenable_file_reports_without_raising(monkeypatch, tmp_path):
@@ -233,8 +244,9 @@ def test_nstools_chatter_is_silenced():
     ("hash", {"signature_valid": True}, True),             # deeper level not yet attempted
     ("hash", {"hash_valid": False, "hash_modified": False}, False),
     ("hash", {"hash_valid": True}, False),
-    # A failure with no hash_modified came from a phase that raised - an unreadable file
-    # rather than a verdict - so it is re-checked. A pass has nothing left to learn.
+    # A failure with no hash_modified is a row verified before that column existed, so it
+    # is re-checked once to learn its kind. verify() never writes this shape itself: a
+    # raised phase fills both hash columns, otherwise this re-check would never end.
     ("hash", {"hash_valid": False}, True),
 ])
 def test_needs_verify_tracks_the_configured_depth(env, depth, columns, expected):
@@ -363,6 +375,33 @@ def test_verify_stage_converges(env):
     f = db.session.get(Files, fid)
     mgmt = _settings(verify=True, depth="hash")["library"]["management"]
     assert tasks._needs_verify(f, mgmt) is False
+
+
+def test_verify_stage_converges_when_nstools_raises(env):
+    """Regression for issue #357: an unopenable file must not be re-verified forever.
+
+    Drive the real verify() through the task with the container refusing to open, then ask
+    the stage whether it wants another pass. Before the fix the raise left hash_modified
+    null, which the stage read as the pre-migration shape and re-queued indefinitely."""
+    redriven = []
+    env.monkeypatch.setattr(tasks, "enqueue_task",
+                            lambda name, *a, **k: redriven.append(name))
+    env.monkeypatch.setattr(tasks.verification_lib, "open_container",
+                            _fake_container(raises=ValueError("Not a valid PFS0 partition")))
+    env.monkeypatch.setattr(tasks, "get_settings",
+                            lambda: _settings(verify=True, depth="hash"))
+    f = env.seed("._Game.nsp")
+    fid = f.id
+
+    tasks.verify_file_task(file_id=fid)
+
+    f = db.session.get(Files, fid)
+    assert (f.signature_valid, f.hash_valid, f.hash_modified) == (False, False, False)
+    assert f.verification_error == "Not a valid PFS0 partition"
+    assert verification_status(f) == verification.STATUS_CORRUPT
+    mgmt = _settings(verify=True, depth="hash")["library"]["management"]
+    assert tasks._needs_verify(f, mgmt) is False
+    assert redriven == ["process_file"]
 
 
 # --- invalidation ----------------------------------------------------------------------------


### PR DESCRIPTION
The exception in the `verify` function, set `hash_modified` to `null`, which `_needs_verify` reads as a pre-migration row, causing it to re-queue indefinitely. While I was at it, I added a filter that prevents hidden files from being read, including Apple Double files, which are one of the triggers for that behavior.